### PR TITLE
copy simulation driving book object

### DIFF
--- a/fleetmanager/model/genetic.py
+++ b/fleetmanager/model/genetic.py
@@ -1061,7 +1061,7 @@ class DrivingTest:
             "omkostning": omkostning,
             "udledning": udledning,
             "uallokeret": uallokeret,
-            "driving_book": driving_book,
+            "driving_book": driving_book.copy(),
             "consequence_calculator": cq
         }
 


### PR DESCRIPTION
Fixes #25 

@sobuos , can you please confirm that when running an automatic simulation on the testing environment the number of unallocated trips correlates with the number in the downloadable driving plan:

![billede](https://github.com/user-attachments/assets/2e5bd47b-9820-413b-b922-59fb6204e257)
![billede](https://github.com/user-attachments/assets/63ddc9f7-805d-4573-a3f1-2d0540c7f3b1)
