### PR TITLE
44 fleetcomplete location exemption

### DIFF
--- a/fleetmanager/extractors/fleetcomplete/updatedb.py
+++ b/fleetmanager/extractors/fleetcomplete/updatedb.py
@@ -111,7 +111,8 @@ def set_starts(ctx):
 @cli.command()
 @click.pass_context
 @click.option("-df", "--description-fields", envvar="DESCRIPTION_FIELDS", required=False)
-def set_vehicles(ctx, description_fields=None):
+@click.option("-el", "--exempt-locations", is_flag=True, default=False)
+def set_vehicles(ctx, description_fields=None, exempt_locations=False):
     fuel_to_type = {
         # benzin til fossilbil
         1: 4,
@@ -137,7 +138,11 @@ def set_vehicles(ctx, description_fields=None):
     vehicles_response = requests.get(url + "Api/Vehicles/get", params=params)
     cars = json.loads(vehicles_response.content)["response"]
     # get currently saved cars to update if changes and save new ones
-    current_cars = pd.read_sql(Query(Cars).statement, engine)
+    current_cars = pd.read_sql(
+        Query(Cars).filter(
+            or_(Cars.deleted == False, Cars.deleted.is_(None)),
+            or_(Cars.disabled == False, Cars.disabled.is_(None))
+        ).statement, engine)
     update_cars = []
     if description_fields is not None:
         description_fields = description_fields.split(",")
@@ -150,7 +155,7 @@ def set_vehicles(ctx, description_fields=None):
         if (
             pd.isna(car["booking"]["homeLocation"])
             or car["booking"]["homeLocation"] not in starts.id.values
-        ):
+        ) and not exempt_locations:
             print(
                 f"Car {id_} did not have any homeLocation or saved location: {car['booking']['homeLocation']}"
             )
@@ -198,7 +203,7 @@ def set_vehicles(ctx, description_fields=None):
 
         location = (
             None
-            if car["booking"]["homeLocation"] is None
+            if car["booking"]["homeLocation"] is None or exempt_locations
             else int(car["booking"]["homeLocation"])
         )
 
@@ -233,8 +238,8 @@ def set_vehicles(ctx, description_fields=None):
             plate=plate,
             make=car["info"]["make"],
             model=car["info"]["model"],
-            type=vehicle_type,
-            fuel=fuel,
+            type=None,  # for now, we're avoiding to set type and fuel - because we don't get the wltp on the api
+            fuel=None,
             # todo implement "auto fill" if the below metrics doesn't exist and similar make model exist
             wltp_fossil=None,  # todo update when we receive confirmation
             wltp_el=None,  # todo update when we receive confirmation
@@ -262,7 +267,7 @@ def set_vehicles(ctx, description_fields=None):
             if not is_car_valid(validate_dict):
                 continue
             for key, value in car_details.items():
-                if key == "id" or pd.isna(value):
+                if key == "id" or pd.isna(value) or current_car.__dict__.get(key) == value:
                     continue
                 setattr(current_car, key, value)
             update_cars.append(current_car)


### PR DESCRIPTION
- Implements a flag for the set-vehicles method in the the FleetComplete extractor. It provides the possibility to opt out of syncing locations from the FleetComplete API and still update new vehicles. Setting fuel - and vehicle type is exempted all along because we will never get wltp as-is, resulting in invalid vehicles.

- In addition, get_or_create function is updated to use the same session and return flag if object is created or fetched and skip unecessary operations in parent. The updates are merged before commiting changes. 