### PR TITLE
43 extractor improvements

### DIFF
--- a/fleetmanager/extractors/skyhost/updatedb.py
+++ b/fleetmanager/extractors/skyhost/updatedb.py
@@ -528,7 +528,8 @@ def set_trackers(ctx, description_fields=None):
     else:
         description_fields = []
 
-    for key in to_list(ctx.obj["SOAP_KEY"]):
+    keys_list = to_list(ctx.obj["SOAP_KEY"])
+    for key_idx, key in enumerate(keys_list):
         agent = SoapAgent(key)
         trackers = Trackers()
 
@@ -536,6 +537,11 @@ def set_trackers(ctx, description_fields=None):
         while (r := agent.execute_action("Trackers_GetAllTrackers")).status_code != 200:
             print("Retrying Trackers_GetAllTrackers")
         trackers.parse(r.text)
+
+        if len(trackers.block) == 0 or 'Marker' not in trackers.frame.columns:
+            logger.info(f"Key no {key_idx + 1} did not return any - or accepted trackers")
+            continue
+
         with Session() as sess:
             banned_cars = (
                 sess.query(Cars.id)


### PR DESCRIPTION
This pull request addresses the following issues from parent #43 :

- [x] Fixes #44: Ability to exempt location update for FleetComplete extractor  
from: #47 

> - Implements a flag for the set-vehicles method in the the FleetComplete extractor. It provides the possibility to opt out of syncing locations from the FleetComplete API and still update new vehicles. Setting fuel - and vehicle type is exempted all along because we will never get wltp as-is, resulting in invalid vehicles.
> - In addition, get_or_create function is updated to use the same session and return flag if object is created or fetched and skip unecessary operations in parent. The updates are merged before commiting changes.



- [x] Fixes #45: Extra check on timestamps for Skyhost data
from #48 
> - Implements an extra check for timestamps in SkyHost logs. On ocassion logs are received which contain no timestamps, which ends up messing with the aggregation. It's allowed to have no timestamp for the last, since this is skipped due to the lack of lat/lon on last StopPos.


- [x] Fixes #46: Skip empty Skyhost tracker response
from #49 
> - implements an extra check of received tracker response from SkyHost. If successful response is received and block is empty or ´Marker´ attribute is missing the key is skipped. Useful for setup with multiple accounts with decentralised control.