### PR TITLE
implement #77 serve simulation highlights and extend storage time

### DIFF
--- a/fleetmanager/api/fleet_simulation/routes.py
+++ b/fleetmanager/api/fleet_simulation/routes.py
@@ -14,7 +14,12 @@ from fleetmanager.configuration import (
     load_simulation_settings,
     validate_settings,
 )
-from fleetmanager.fleet_simulation import fleet_simulator, simulation_results_to_excel, load_fleet_simulation_history
+from fleetmanager.fleet_simulation import (
+    fleet_simulator,
+    load_fleet_simulation_history,
+    load_simulation_highlights,
+    simulation_results_to_excel
+)
 from fleetmanager.tasks import get_task_id, run_fleet_simulation
 
 from ..configuration.schemas import (
@@ -29,7 +34,8 @@ from .schemas import (
     FleetSimulationOptions,
     FleetSimulationOut,
     FleetSimulationResult,
-    FleetSimulationHistory
+    FleetSimulationHistory,
+    SimulationHighlight
 )
 
 router = APIRouter(
@@ -137,3 +143,9 @@ async def get_simulation(
 async def get_fleet_simulation_history(session: Session = Depends(get_session)):
     r = redis.Redis(host="redis", port=6379)
     return load_fleet_simulation_history(session, r)
+
+
+@router.get("/highlights/latest", response_model=list[SimulationHighlight])
+async def get_fleet_simulation_history_latest(n_simulations: int = 5, session: Session = Depends(get_session)):
+    r = redis.Redis.from_url(os.getenv("CELERY_BACKEND_URL"))
+    return load_simulation_highlights(r=r, session=session, n=n_simulations)

--- a/fleetmanager/api/fleet_simulation/schemas.py
+++ b/fleetmanager/api/fleet_simulation/schemas.py
@@ -90,3 +90,15 @@ class FleetSimulationHistory(BaseModel):
     location: str
     locations: str | None
     simulation_date: str
+
+
+class SimulationHighlight(BaseModel):
+    id: str
+    unallocated: int
+    financial_savings: float
+    co2e_savings: float
+    location_ids: list[int]
+    simulation_type: Literal["fleet", "goal"]
+    addresses: list[str]
+    simulation_date: str
+    fleet_change: int

--- a/fleetmanager/tasks/celery.py
+++ b/fleetmanager/tasks/celery.py
@@ -2,7 +2,7 @@ import os
 
 from celery import Celery
 from kombu import Queue, serialization
-from datetime import datetime, date
+from datetime import datetime, timedelta
 from uuid import uuid4
 
 from fleetmanager.api.fleet_simulation.schemas import FleetSimulationOptions
@@ -28,7 +28,7 @@ serialization.register_pickle()
 serialization.enable_insecure_serializers()
 
 app.conf.task_queues = [Queue(queue)]
-
+app.conf.result_expires = timedelta(days=int(os.getenv("TTL", 30))).total_seconds()  # 30 day default TTL
 
 @app.task(queue=queue)
 def run_fleet_simulation(settings: FleetSimulationOptions):


### PR DESCRIPTION
- new highlights endpoint
- simulation highlight schema
- utility function to load and parse latest simulation highlights
- extend default TTL of simulation tasks to 30 days

feature #77 