### PR TITLE
fix #96 - include all weeks, aslo empty for locations

### DIFF
--- a/fleetmanager/api/statistics/schemas.py
+++ b/fleetmanager/api/statistics/schemas.py
@@ -162,6 +162,8 @@ class LocationUsage(BaseView):
 
 class WeekLocationActivity(BaseModel):
     week_name: str
+    start_date: date
+    end_date: date
     activity: float
     average_activity: Optional[float] = None # convert to computed_field if migrating to pydantic v2
 


### PR DESCRIPTION
eases the task of presenting activity data in the frontend and implements precise week dates for filtering

- include iso week start - and end dates in schema return
- function for getting the weeks from since date to today
- move dialect week functions to iso week standard
- sanitation on excluded weeks

closes #96 