### PR TITLE
functionality to enforce restriction on goal simulation vehicle count

### DIFF
--- a/fleetoptimiser-frontend/app/(logged-in)/TopNavigation.tsx
+++ b/fleetoptimiser-frontend/app/(logged-in)/TopNavigation.tsx
@@ -8,7 +8,7 @@ import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import QueryStatsIcon from '@mui/icons-material/QueryStats';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import Image from 'next/image';
-import { useAppSelector } from '@/components/redux/hooks';
+import {useAppDispatch, useAppSelector} from '@/components/redux/hooks';
 import Link from 'next/link';
 import { Suspense, useState } from 'react';
 import ExpandLess from '@mui/icons-material/ExpandLess';
@@ -31,6 +31,7 @@ import MenuOutlinedIcon from '@mui/icons-material/MenuOutlined';
 import KeyboardDoubleArrowLeftIcon from '@mui/icons-material/KeyboardDoubleArrowLeft';
 import HomeIcon from '@mui/icons-material/Home';
 import { signOut } from 'next-auth/react';
+import { prepareGoalSimulation } from "@/components/redux/SimulationSlice";
 
 type Props = {
     logoutRedirect: string;
@@ -39,6 +40,8 @@ type Props = {
 const TopNavigation = ({ logoutRedirect }: Props) => {
     const [showNavBar, setShowNavBar] = useState<boolean>(false);
     const pathname = usePathname();
+
+    const dispatch = useAppDispatch();
 
     const isSelected = (path: string, contains: boolean = false) => {
         return pathname === path || (contains && pathname.includes(path))
@@ -166,7 +169,13 @@ const TopNavigation = ({ logoutRedirect }: Props) => {
                                     </span>
                                 </Tooltip>
                             ) : (
-                                <ListItemButton onClick={() => router.push('/goal')} disabled={disableGoalLink} selected={isSelected('/goal')}>
+                                <ListItemButton
+                                    onClick={async () => {
+                                        await dispatch(prepareGoalSimulation());
+                                        router.push('/goal');
+                                    }}
+                                    disabled={disableGoalLink}
+                                    selected={isSelected('/goal')}>
                                     <ListItemIcon className="ml-4">
                                         <MemoryIcon />
                                     </ListItemIcon>

--- a/fleetoptimiser-frontend/app/(logged-in)/setup/VehiclePicker.tsx
+++ b/fleetoptimiser-frontend/app/(logged-in)/setup/VehiclePicker.tsx
@@ -30,6 +30,8 @@ import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import MemoryIcon from '@mui/icons-material/Memory';
 import { useRouter } from 'next/navigation';
 import DownloadIcon from '@mui/icons-material/Download';
+import { prepareGoalSimulation } from "@/components/redux/SimulationSlice";
+import { useAppDispatch } from "@/components/redux/hooks";
 
 interface VehiclePickerProps {
     vehicles: VehicleWithStatus[];
@@ -82,6 +84,7 @@ const DepartmentVehicleFilter = ({ allDepartments, selectedDepartment, setSelect
 
 export default function VehiclePicker({ vehicles, selectedVehicleIds, onSelectionChange, isLoading, simulationDisabled, onDownload }: VehiclePickerProps) {
     const router = useRouter();
+    const dispatch = useAppDispatch();
 
     // show progressively more vehicle data in the table
     const isXlScreen = useMediaQuery({ minWidth: '1280px' });
@@ -296,7 +299,10 @@ export default function VehiclePicker({ vehicles, selectedVehicleIds, onSelectio
                             <Button
                                 disabled={simulationDisabled}
                                 startIcon={<MemoryIcon />}
-                                onClick={() => router.push('/goal')}
+                                onClick={async () => {
+                                  await dispatch(prepareGoalSimulation());
+                                  router.push('/goal');
+                              }}
                                 variant="contained"
                                 size="small"
                             >


### PR DESCRIPTION
it is not allowed to bring above current count values on vehicle types from manual simulation to goal simulation
clicking to automatic simulation from manual simulation will enforce a sanity check on the selected counts