### PR TITLE
assert that simulation fleets does not only consist of endLeasing status

### DIFF
--- a/fleetoptimiser-frontend/app/(logged-in)/TopNavigation.tsx
+++ b/fleetoptimiser-frontend/app/(logged-in)/TopNavigation.tsx
@@ -64,13 +64,13 @@ const TopNavigation = ({ logoutRedirect }: Props) => {
     // User must choose cars that have been driven in the given period to continue
     const disableSimulationLink = useAppSelector(
         (state) =>
-            state.simulation.selectedVehicles.filter((car) => car.status === 'ok' || car.status === 'locationChanged' || car.status === 'leasingEnded')
+            state.simulation.selectedVehicles.filter((car) => car.status === 'ok' || car.status === 'locationChanged')
                 .length === 0
     );
 
     const disableGoalLink = useAppSelector((state) => {
         const filteredVehicles = state.simulation.selectedVehicles.filter(
-            (car) => car.status === 'ok' || car.status === 'locationChanged' || car.status === 'leasingEnded'
+            (car) => car.status === 'ok' || car.status === 'locationChanged'
         );
         return filteredVehicles.length === 0 || filteredVehicles.length > 100;
     });

--- a/fleetoptimiser-frontend/app/(logged-in)/setup/page.tsx
+++ b/fleetoptimiser-frontend/app/(logged-in)/setup/page.tsx
@@ -20,7 +20,7 @@ import NoSelectableVehicles from "@/app/(logged-in)/setup/NoSelectableVehicles";
 
 export default function Home() {
     const dispatch = useAppDispatch();
-    const simulationDisabled = useAppSelector((state) => state.simulation.selectedVehicles.every(car => !['ok', 'locationChanged', 'leasingEnded'].includes(car.status)))
+    const simulationDisabled = useAppSelector((state) => state.simulation.selectedVehicles.every(car => !['ok', 'locationChanged'].includes(car.status)))
     useEffect(() => {
         dispatch(fetchSimulationSettings());
     }, [dispatch]);


### PR DESCRIPTION
assert that simulation fleets does not consist of endLeasing status vehicles ony
It's not guaranteed that vehicles with endLeasing status has been active, thus block sims where only this/or notActive type is selected