### PR TITLE
fix #127 stop relying on id count when count eligble vehicles

### DIFF
--- a/fleetmanager/statistics/util.py
+++ b/fleetmanager/statistics/util.py
@@ -1684,7 +1684,10 @@ def eligible_saved_vehicles(since_date: datetime.date, session: Session):
             or_(Cars.disabled.is_(None), Cars.disabled == False),
             or_(Cars.deleted.is_(None), Cars.deleted == False)
         ),
-        Cars.id < 1000000  # exclude test vehicles
+        Cars.omkostning_aar.isnot(None),
+        Cars.type.isnot(None),
+        Cars.fuel.isnot(None),
+        Cars.location.isnot(None)
     ).scalar()
     return total_eligible_cars
 


### PR DESCRIPTION
relying on id count is stupid and not scalable. Instead filter on filled attributes

closes #127 