### PR TITLE
fix #129 - show graphs at one entry

### DIFF
--- a/fleetoptimiser-frontend/app/(logged-in)/dashboard/activity/(VehicleActivity)/VehicleActivityDashboard.tsx
+++ b/fleetoptimiser-frontend/app/(logged-in)/dashboard/activity/(VehicleActivity)/VehicleActivityDashboard.tsx
@@ -78,7 +78,10 @@ const VehicleActivityDashboard = ({
     };
 
     const fileNameAppendix = `${start}-${end}-${locations?.length ?? 'alle'}_lokationer-${vehicles?.length ?? 'alle'}_koeretoejer`;
-
+    const impliedCellHeight = 40
+    const impliedBaseHeight = 210
+    const vehicleHeight = impliedBaseHeight + ((heatMapData.data?.vehicleGroup.km?.length || 1) * impliedCellHeight);
+    const locationHeight = impliedBaseHeight + ((heatMapData.data?.locationGroup.km?.length || 1) * impliedCellHeight);
     return (
         <div>
             <div className="flex items-center py-8">
@@ -134,7 +137,7 @@ const VehicleActivityDashboard = ({
                 {heatMapData.data && (
                     <>
                         <TabPanel value="locations">
-                            <div style={{ height: String(210 + (heatMapData ? (heatMapData.data.locationGroup.km.length - 1) * 40 : 0)) + 'px' }}>
+                            <div style={{height: `${locationHeight}px`}}>
                                 <DownloadableGraph filename={`loktaionsaktivitet-${fileNameAppendix}.png`}>
                                     <DrivingHeatmapKm
                                         setLocationZoom={goToLocation}
@@ -145,7 +148,7 @@ const VehicleActivityDashboard = ({
                             </div>
                         </TabPanel>
                         <TabPanel value="vehicles">
-                            <div style={{ height: String(210 + (heatMapData ? (heatMapData.data.vehicleGroup.km.length - 1) * 40 : 0)) + 'px' }}>
+                            <div style={{height: `${vehicleHeight}px`}}>
                                 <DownloadableGraph filename={`koeretoejsaktivitet-${fileNameAppendix}.png`}>
                                     <DrivingHeatmapKm
                                         setLocationZoom={goToLocation}

--- a/fleetoptimiser-frontend/app/(logged-in)/dashboard/timeactivity/(TimeActivity)/TimeActivityDashboard.tsx
+++ b/fleetoptimiser-frontend/app/(logged-in)/dashboard/timeactivity/(TimeActivity)/TimeActivityDashboard.tsx
@@ -51,7 +51,9 @@ function TimeActivityDashboard({ end, locations, forvaltninger, start, departmen
         },
     });
     const fileNameAppendix = `${start}-${end}-${locations?.length ?? 'alle'}_lokationer-${vehicles?.length ?? 'alle'}_koeretoejer`;
-
+    const impliedCellHeight = 40
+    const impliedBaseHeight = 210
+    const computedHeight = impliedBaseHeight + ((heatMapData.data?.length || 1) * impliedCellHeight);
     return (
         <div>
             <>
@@ -80,7 +82,7 @@ function TimeActivityDashboard({ end, locations, forvaltninger, start, departmen
                     </div>
                 )}
                 {heatMapData.data && (
-                    <div style={{ height: String(210 + (heatMapData ? (heatMapData.data.length - 1) * 40 : 0)) + 'px' }}>
+                    <div style={{height: `${computedHeight}px`}}>
                         <DownloadableGraph filename={`tidsaktivitet-${fileNameAppendix}.png`}>
                             <TimeActivityHeatMap data={heatMapData.data} threshold={colorThreshold} />
                         </DownloadableGraph>


### PR DESCRIPTION
previously when just one entry was present it would evaluate to 210px; too short to show the single row in the heatmapt.
Adjust such that when loading either just one location or one vehicle it will compute to 250px which correctly displays the row.

closes #129 