### PR TITLE
fix #134 - potential wrong current fleet construction

### DIFF
--- a/fleetmanager/model/genetic.py
+++ b/fleetmanager/model/genetic.py
@@ -1249,7 +1249,7 @@ class AutomaticSimulation:
         current_fleet = []
         for current_id in self.current_vehicles:
             try:
-                vehicle_object = next(filter(lambda unique_vehicle: str(current_id) in unique_vehicle[-1], self.fh.original_fleet))
+                vehicle_object = next(filter(lambda unique_vehicle: str(current_id) in unique_vehicle[-1].split(','), self.fh.original_fleet))
             except StopIteration:
                 continue
 


### PR DESCRIPTION
run_current in automatic solution can potentially build the wrong fleet for comparison. This will construct a vehicle usage and driving book with wrong vehicle makes and models.

Without changing the count on automatic sim, the bug could lead to wrong counts on current fleets.

Issue happens because the current fleet is build from a concatenated string of unique vehicles from the db that share attributes. To find exactly the current vehicle and populate a simulation fleet, the vehicle_id is matched with the string. The string matching is not accurate because it can match 26 on 264 - pulling out the wrong vehicle.

Splitting the unique vehicle string will make the match accurate and ensure a proper match. fleetmanager/model/genetic.py - run_current

closes #134 