### PR TITLE
fix row access in puma vehicle extraction

### DIFF
--- a/fleetmanager/extractors/puma/updatedb.py
+++ b/fleetmanager/extractors/puma/updatedb.py
@@ -226,7 +226,7 @@ def set_vehicles(ctx, description_fields=None):
                     [
                         attr
                         for field in description_fields
-                        if (attr := vehicle.get(field))
+                        if (attr := vehicle.__dict__.get(field))
                     ]
                 ),
             }


### PR DESCRIPTION
can't access a sqlalchemy row with get method needs the dict version