### PR TITLE
fix #188: align default electrical vehicle range

### DIFF
--- a/fleetmanager/model/genetic.py
+++ b/fleetmanager/model/genetic.py
@@ -812,7 +812,7 @@ class DrivingTest:
             )
         elif 3 in self.fleet_handler.grouped_sorting.keys():
             longest_ranging_electrical_vehicle = max([
-                (idx, vehicle.range) for idx, vehicle in enumerate(self.fleet_handler.fleet)
+                (idx, vehicle.range or 500) for idx, vehicle in enumerate(self.fleet_handler.fleet)
                 if vehicle.type == 3
             ], key=lambda x: x[1])
             best_electrical_vehicle = self.fleet_handler.fleet[longest_ranging_electrical_vehicle[0]]  # adding el


### PR DESCRIPTION
closes #188 

Reproduce error by running an automatic simulation with isolated electrical vehicles with no range selected.
- edit a couple or all of vehicles range to null in dummy_data.sql
- select data range 2022-03-01 - 2022-03-31 
- select one of the electrical vehicles with null range for simulation
- select the other electrical vehicle with range null as test vehicle to restrain optimisation to the selected vehicles

throws: 
`TypeError("'>' not supported between instances of 'NoneType' and 'NoneType'")`

Aligning with manual simulation where default is set to 500 if no specific range is saved on the vehicle.