### PR TITLE
fix #104: use backend returned dates landing page activity graph

### DIFF
--- a/fleetoptimiser-frontend/app/(logged-in)/(landing-page)/ActivityGraph.tsx
+++ b/fleetoptimiser-frontend/app/(logged-in)/(landing-page)/ActivityGraph.tsx
@@ -8,6 +8,8 @@ interface ActivityHeatmapProps {
         data: {
             x: string;
             y: number;
+            start_date: string;
+            end_date: string;
         }[];
     }[];
 }
@@ -46,9 +48,15 @@ const normalizeData = (data: ActivityHeatmapProps['data']) => {
         data: allWeeks
             .map((week) => {
                 const weekData = location.data.find((d) => d.x === week);
+                const { start, end } = weekData
+                    ? { start: weekData.start_date, end: weekData.end_date }
+                    : getDateRangeFromYearWeek(week);
+
                 return {
                     x: week,
-                    y: weekData ? weekData.y : 0,
+                    y: weekData?.y ?? 0,
+                    start_date: start,
+                    end_date: end,
                 };
             })
             .sort((a, b) => {
@@ -120,8 +128,7 @@ const ActivityHeatmap = ({ data, showKeys = true }: ActivityHeatmapProps & { sho
                 }}
                 onClick={(cell) => {
                     const locationId = addressToIdMap[cell.serieId];
-                    const { start, end } = getDateRangeFromYearWeek(cell.data.x);
-                    window.location.href = `/dashboard/activity?startdate=${start}&enddate=${end}&locations=${locationId}`;
+                    window.location.href = `/dashboard/activity?startdate=${cell.data.start_date}&enddate=${cell.data.end_date}&locations=${locationId}`;
                 }}
                 theme={{
                     labels: { text: { fontWeight: 'bold', fontSize: '0.75rem' } },

--- a/fleetoptimiser-frontend/app/(logged-in)/(landing-page)/LandingPageGraphs.tsx
+++ b/fleetoptimiser-frontend/app/(logged-in)/(landing-page)/LandingPageGraphs.tsx
@@ -26,6 +26,8 @@ export default function LandingPageGraphs({ usageData, activityData }: { usageDa
             data: locationData.weeks.map((week) => ({
                 x: week.week_name,
                 y: week.average_activity,
+                start_date: week.start_date,
+                end_date: week.end_date,
             })),
         }));
 

--- a/fleetoptimiser-frontend/components/hooks/useGetLandingPage.tsx
+++ b/fleetoptimiser-frontend/components/hooks/useGetLandingPage.tsx
@@ -33,6 +33,8 @@ interface WeekLocationActivity {
     week_name: string;
     activity: number;
     average_activity: number;
+    start_date: string;
+    end_date: string;
 }
 
 export interface LocationActivity extends BaseView {


### PR DESCRIPTION
closes #104 

Test by checking network tab with returned response for the activity data. Weeks include start and end dates. 
This now correlates with the dates that are passed to the window.location.href when clicking a cell in the activity graph on the landing page. 
