### PR TITLE
bug: catch inconsistent dt format from sh

### DIFF
--- a/fleetmanager/extractors/skyhost/updatedb.py
+++ b/fleetmanager/extractors/skyhost/updatedb.py
@@ -580,14 +580,6 @@ def set_trackers(ctx, description_fields=None):
                 get_or_create(Session, Cars, car)
 
 
-def to_dt_timestamp(ts):
-    try:
-        dt = datetime.strptime(ts, "%Y-%m-%dT%H:%M:%S")
-    except ValueError:
-        dt = datetime.strptime(ts, "%Y-%m-%dT%H:%M:%S.%f")
-    return dt
-
-
 def get_trips(car_id, key, from_date=None):
     current_time = datetime.now()
     min_time = datetime(2022, 2, 24)


### PR DESCRIPTION
SH returns yet another dt string format. 
Python 3.10 datetime fromisoformat is not support, hence the usage of dateutil parsers to support all common types.

ValueError: time data '2025-06-26T18:56:53.01+00:00' does not match format '%Y-%m-%dT%H:%M:%S%z'