### PR TITLE
implement #212: test vehicle status chip in configuraiton

### DIFF
--- a/fleetoptimiser-frontend/app/(logged-in)/configuration/ConfigTable.tsx
+++ b/fleetoptimiser-frontend/app/(logged-in)/configuration/ConfigTable.tsx
@@ -135,6 +135,7 @@ const VehicleConfigTable = ({ vehicleData, dropDownData }: { vehicleData: Vehicl
     const getStatus = (vehicle: Vehicle) => {
         if (vehicle.disabled) return <Chip variant="outlined" style={{ color: '#888', borderColor: '#888' }} label="Deaktiveret"></Chip>;
         if (hasMissingData(vehicle)) return <Chip variant="outlined" color="error" label="Manglende metadata"></Chip>;
+        if (vehicle.test_vehicle) return <Chip variant="outlined" color="primary" label="Testkøretøj"></Chip>; // prioritising to show missing metadata on test vehicles
         if (hasEndedLeasing(vehicle)) return <Chip style={{ color: '#ca8a04', borderColor: '#ca8a04' }} variant="outlined" label="Udløbet leasing"></Chip>;
         return <Chip variant="outlined" color="success" label="OK" deleteIcon={<DoneIcon />} onDelete={() => 'render icon'}></Chip>;
     };
@@ -148,6 +149,7 @@ const VehicleConfigTable = ({ vehicleData, dropDownData }: { vehicleData: Vehicl
                 accessorFn: (row) => {
                     if (row.disabled) return 'Deaktiveret';
                     if (hasMissingData(row)) return 'Manglende metadata';
+                    if (row.test_vehicle) return 'Testkøretøj';
                     if (hasEndedLeasing(row)) return 'Udløbet leasing';
                     return 'OK';
                 },


### PR DESCRIPTION
closes #212 

Shows a chip for test vehicles, also making it filterable in the column.
Prioritised showing missing meta data for test vehicles as it is necessary for a test vehicle to be valid.