### PR TITLE
catch aborted client connection at get token stage

### DIFF
--- a/fleetoptimiser-frontend/middleware.ts
+++ b/fleetoptimiser-frontend/middleware.ts
@@ -4,7 +4,14 @@ import type { NextRequest } from 'next/server';
 import { getToken } from 'next-auth/jwt';
 
 export async function middleware(req: NextRequest) {
-    const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+    let token
+    try {
+        token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+    } catch (e){
+        console.error('Token verification failed:', e);
+        return NextResponse.redirect(new URL('/login?message=notoken', req.url));
+    }
+
     if (process.env.ROLE_CHECK) {
         if (token && token.role_valid) {
             return NextResponse.next();


### PR DESCRIPTION
Scanners/bots hit the site, triggering the middleware's getToken() call which performs JWT crypto operations. The bots then abort the connection before the response completes, which triggers 499 errors in nginx.
When next tries to finalize the aborted request, its internal state is already torn down, causing it to call .digest() on a null crypto object.

```
TypeError: Cannot read properties of null (reading 'digest')
    at /app/node_modules/next/dist/compiled/next-server/
    at AsyncLocalStorage.run (node:async_hooks:338:14)
    at e_ (/app/node_modules/next/dist/compiled/next-server/
    at /app/node_modules/next/dist/compiled/next-server/
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```