### PR TITLE
implement #211: move running task signal to redis

### DIFF
--- a/fleetmanager/tasks/cache_utils.py
+++ b/fleetmanager/tasks/cache_utils.py
@@ -1,16 +1,43 @@
 import os
+from functools import wraps
 from redis import Redis
 import pickle
 
 
-def get_redis_client():
-    return Redis.from_url(os.getenv("CELERY_BACKEND_URL"))
+class RedisNotConfiguredError(Exception):
+    pass
 
-def get_cached_data(key: str):
-    r = get_redis_client()
+
+def get_redis_client():
+    backend_url = os.getenv("CELERY_BACKEND_URL")
+    if not backend_url:
+        raise RedisNotConfiguredError(
+            "CELERY_BACKEND_URL environment variable is not set"
+        )
+    r = Redis.from_url(backend_url)
+    r.ping()
+    return r
+
+
+def require_redis(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(get_redis_client(), *args, **kwargs)
+    return wrapper
+
+
+@require_redis
+def get_cached_data(r: Redis, key: str):
     cached_data = r.get(key)
     return pickle.loads(cached_data) if cached_data else None
 
-def set_cached_data(key: str, data):
-    r = get_redis_client()
+
+@require_redis
+def set_cached_data(r: Redis, key: str, data):
     r.set(key, pickle.dumps(data))
+
+
+@require_redis
+def delete_cached_data(r: Redis, key: str):
+    r.delete(key)
+

--- a/fleetmanager/tasks/running_tasks.py
+++ b/fleetmanager/tasks/running_tasks.py
@@ -1,0 +1,25 @@
+import os
+from fleetmanager.tasks.cache_utils import get_cached_data, set_cached_data, delete_cached_data
+
+
+def key_constructor(datestring: str, process: str):
+    return f"running_task:{os.getenv('CELERY_QUEUE', 'default')}:{process}:{datestring}"
+
+
+def set_task_running(sim_start: str, process: str):
+    if sim_start is None:
+        return
+    set_cached_data(key_constructor(sim_start, process), "running")
+
+
+def is_task_running(sim_start: str, process: str) -> bool:
+    if sim_start is None:
+        # to allow isolated runs without api
+        return True
+    return bool(get_cached_data(key_constructor(sim_start, process)))
+
+
+def clear_task_signal(sim_start: str, process: str):
+    if sim_start is None:
+        return
+    delete_cached_data(key_constructor(sim_start, process))


### PR DESCRIPTION
closes #211 

- add new utility to signal running tasks in redis for location precision tests and automatic simulations
- wrap redis cache utilities to ensure operability with and without running celery and redis/rmq
- update calls from writing/clearing files to redis operations