### PR TITLE
fix #244: correct spelling of RECEIVED in polling hooks

### DIFF
--- a/fleetoptimiser-frontend/components/hooks/useSimulateFleet.tsx
+++ b/fleetoptimiser-frontend/components/hooks/useSimulateFleet.tsx
@@ -128,7 +128,7 @@ function useSimulateFleet(initialDataId?: string) {
                 data.status === 'STARTED' ||
                 data.status === 'RETRY' ||
                 data.status === 'PROGRESS' ||
-                data.status === 'RECIEVED'
+                data.status === 'RECEIVED'
                     ? 500
                     : false;
         }

--- a/fleetoptimiser-frontend/components/hooks/useSimulateGoal.tsx
+++ b/fleetoptimiser-frontend/components/hooks/useSimulateGoal.tsx
@@ -119,7 +119,7 @@ function useSimulateGoal(initialDataId?: string) {
                 data.status === 'STARTED' ||
                 data.status === 'RETRY' ||
                 data.status === 'PROGRESS' ||
-                data.status === 'RECIEVED'
+                data.status === 'RECEIVED'
                     ? 500
                     : false;
         },


### PR DESCRIPTION
Replace misspelled `RECIEVED` with `RECEIVED` in `useSimulateFleet.tsx` and `useSimulateGoal.tsx` to match Celery's built-in state.

Closes #244