### PR TITLE
implement: add centralised vehicle extractor upserts

### DIFF
--- a/fleetmanager/extractors/fleetcomplete/updatedb.py
+++ b/fleetmanager/extractors/fleetcomplete/updatedb.py
@@ -11,12 +11,10 @@ import click
 import pandas as pd
 import requests
 from dateutil.relativedelta import relativedelta
-from pydantic import ValidationError
 from sqlalchemy import create_engine, func, or_, select, text, bindparam
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.orm.query import Query
 
-from fleetmanager.api.configuration.schemas import Vehicle
 from fleetmanager.api.location.schemas import AllowedStart as AllowedStartSchema
 from fleetmanager.data_access import (
     AllowedStarts,
@@ -28,7 +26,14 @@ from fleetmanager.data_access import (
     VehicleTypes,
 )
 from fleetmanager.data_access.dbschema import RoundTripSegments
-from fleetmanager.extractors.util import get_allowed_starts_with_additions
+from fleetmanager.extractors.util import (
+    apply_dmr_data,
+    get_allowed_starts_with_additions,
+    get_plate_info_from_api,
+    is_car_valid,
+    save_vehicle,
+    vehicle_needs_dmr_data,
+)
 from fleetmanager.logging import logging
 from fleetmanager.model.roundtripaggregator import aggregator, process_car_roundtrips
 from fleetmanager.model.roundtripaggregator import aggregating_score as score
@@ -114,15 +119,9 @@ def set_starts(ctx):
 @click.option("-el", "--exempt-locations", is_flag=True, default=False)
 def set_vehicles(ctx, description_fields=None, exempt_locations=False):
     fuel_to_type = {
-        # benzin til fossilbil
-        1: 4,
-        # diesel til fossilbil
-        2: 4,
-        # el til elbil
-        3: 3,
-    }
-
-    default_types = {
+        1: 4,  # benzin to fossilbil
+        2: 4,  # diesel to fossilbil
+        3: 3,  # el to  elbil
     }
 
     Session = ctx.obj["Session"]
@@ -130,14 +129,11 @@ def set_vehicles(ctx, description_fields=None, exempt_locations=False):
     params = ctx.obj["params"]
     url = ctx.obj["url"]
 
-    # Cars start
-    # getting vehicle settings for setting type ids on the cars
     starts = pd.read_sql(Query(AllowedStarts).statement, engine)
     fuel_settings = pd.read_sql(Query(FuelTypes).statement, engine)
     vehicle_settings = pd.read_sql(Query(VehicleTypes).statement, engine)
     vehicles_response = requests.get(url + "Api/Vehicles/get", params=params)
     cars = json.loads(vehicles_response.content)["response"]
-    # get currently saved cars to update if changes and save new ones
     current_cars = {car.id: car.to_dict() for _, car in pd.read_sql(Query(Cars).statement, engine).iterrows()}
 
     if description_fields is not None:
@@ -145,7 +141,7 @@ def set_vehicles(ctx, description_fields=None, exempt_locations=False):
     else:
         description_fields = []
 
-    for car in cars:
+    for k, car in enumerate(cars):
         id_ = car["id"]
 
         current_car = current_cars.get(id_, {})
@@ -158,47 +154,28 @@ def set_vehicles(ctx, description_fields=None, exempt_locations=False):
             logger.info(
                 f"Car {id_} did not have any homeLocation or saved location: {car['booking']['homeLocation']}"
             )
-            # continue
 
         plate = car["plate"]
         if plate is not None and len(plate) > 7:
             plate = plate[:7]
+        if plate is None and current_car:
+            existing_plate = current_car.get("plate")
+            if existing_plate and not pd.isna(existing_plate):
+                plate = existing_plate
 
-        if all(
-            [plate is None, car["info"]["make"] is None, car["info"]["model"] is None]
-        ):
+        if all([plate is None, car["info"]["make"] is None, car["info"]["model"] is None]):
             continue
 
         fuel = None
         vehicle_type = None
         if car["info"]["fuelType"]:
             fuel = car["info"]["fuelType"]
-            if fuel in fuel_settings.name.values:
-                fuel = int(
-                    fuel_settings[fuel_settings.name == fuel].refers_to.values[0]
-                )
-            else:
-                fuel = None
-
+            fuel = int(fuel_settings[fuel_settings.name == fuel].refers_to.values[0]) if fuel in fuel_settings.name.values else None
         if car["info"]["vehicleType"]:
-            # check the refers to
             vehicle_type = car["info"]["vehicleType"]
-            if vehicle_type in vehicle_settings.name.values:
-                vehicle_type = int(
-                    vehicle_settings[
-                        vehicle_settings.name == vehicle_type
-                    ].refers_to.values[0]
-                )
-            else:
-                vehicle_type = None
+            vehicle_type = int(vehicle_settings[vehicle_settings.name == vehicle_type].refers_to.values[0]) if vehicle_type in vehicle_settings.name.values else None
         if vehicle_type is None and fuel:
-            # best guess
             vehicle_type = fuel_to_type[fuel]
-
-        model = car["info"]["model"]
-        if vehicle_type is None and fuel is None and model in default_types.keys():
-            fuel = default_types[model]["fuel"]
-            vehicle_type = default_types[model]["type"]
 
         location = (
             None
@@ -206,44 +183,30 @@ def set_vehicles(ctx, description_fields=None, exempt_locations=False):
             else int(car["booking"]["homeLocation"])
         )
 
-        department_exists = (
-            False if car["groups"] is None or len(car["groups"]) == 0 else True
-        )
         department = None
-        departments = None if not department_exists else car["groups"]
-        if departments:
-            response_ = run_request(
-                url + "Api/Organization/ObjectGroups/get", params=params
-            )
+        if car["groups"]:
+            response_ = run_request(url + "Api/Organization/ObjectGroups/get", params=params)
             response = json.loads(response_.content)["response"]
             if response:
-                department = map(
-                    lambda final_group: final_group["title"]
-                    .replace("Gruppe:", "")
-                    .strip(),
-                    filter(
-                        lambda qualified_group: "Gruppe:" in qualified_group["title"],
-                        filter(lambda group: group["id"] in departments, response),
+                department = next(
+                    (
+                        g["title"].replace("Gruppe:", "").strip()
+                        for g in response
+                        if g["id"] in car["groups"] and "Gruppe:" in g["title"]
                     ),
+                    None,
                 )
-                try:
-                    department = next(department)
-                except StopIteration:
-                    department = None
-                    pass
 
         car_details = dict(
-            id=car["id"],
+            id=id_,
             plate=plate,
             make=car["info"]["make"],
             model=car["info"]["model"],
-            type=None,  # for now, we're avoiding to set type and fuel - because we don't get the wltp on the api
-            fuel=None,
-            # todo implement "auto fill" if the below metrics doesn't exist and similar make model exist
-            wltp_fossil=None,  # todo update when we receive confirmation
-            wltp_el=None,  # todo update when we receive confirmation
-            co2_pr_km=None,  # todo update when we receive confirmation
-            range=None,  # todo update when we receive confirmation
+            type=vehicle_type,
+            fuel=fuel,
+            wltp_fossil=None,
+            wltp_el=None,
+            range=None,
             location=None if location is None else int(location),
             department=department,
             description=" ".join(
@@ -251,117 +214,20 @@ def set_vehicles(ctx, description_fields=None, exempt_locations=False):
             ),
         )
 
-        with Session.begin() as session:
-            if current_car:
-                if not update_car(
-                    car_details, current_car
-                ):
-                    continue
+        dmr_info = {}
+        if plate and vehicle_needs_dmr_data(current_car if current_car else None):
+            try:
+                dmr_info = get_plate_info_from_api(plate)
+            except Exception as e:
+                logger.info(f"DMR lookup failed for plate {plate}: {e}")
+        dmr_keys = apply_dmr_data(car_details, dmr_info)
 
-                db_current_car = session.query(Cars).filter(Cars.id == id_).first()
-                if not db_current_car:
-                    # not possible
-                    continue
-
-                validate_dict = compare_new_old(car_details, current_car)
-                if not is_car_valid(validate_dict):
-                    continue
-
-                values_changed = False
-                for key, value in car_details.items():
-                    if key == "id" or pd.isna(value) or current_car.get(key) == value:
-                        continue
-                    values_changed = True
-                    setattr(db_current_car, key, value)
-
-                if values_changed:
-                    session.add(db_current_car)
-
-            elif is_car_valid(car_details):
-                session.add(Cars(**car_details))
-    # Cars end
-
-
-@cli.command()
-@click.pass_context
-def set_trips(ctx):
-    session = ctx.obj["Session"]
-    engine = ctx.obj["engine"]
-    params = ctx.obj["params"]
-    url = ctx.obj["url"]
-
-    all_cars = pd.read_sql(Query(Cars).statement, engine)
-    start_locations = pd.read_sql(Query(AllowedStarts).statement, engine)
-    address2id = {a.address: a.id for a in start_locations.itertuples()}
-
-    now = datetime.datetime.now()
-
-    for car in all_cars.itertuples():
-        car_trips = []
-        lat, lon, address_id = None, None, None
-        if not pd.isna(car.location) and int(car.location) in start_locations.id.values:
-            logger.info(f"Pulling trips for {car.id}")
-            lat, lon, address_id = start_locations[start_locations.id == car.location][
-                ["latitude", "longitude", "id"]
-            ].values[0]
-        else:
+        validation_source = compare_new_old(car_details, current_car) if current_car else car_details
+        if not is_car_valid(validation_source):
             continue
 
-        start_date = datetime.datetime(year=2022, month=1, day=20)
-        with session() as s:
-            last_trip_end = (
-                s.query(func.max(Trips.end_time))
-                .filter(Trips.car_id == car.id)
-                .first()[0]
-            )
-        if last_trip_end is not None:
-            start_date = last_trip_end
-
-        month_pairs = quantize_months(start_date, now)
-        for k, (start_month, end_month) in enumerate(month_pairs):
-            params["objectId"] = car.id
-            params["begTimestamp"] = start_month
-            params["endTimestamp"] = end_month
-
-            response_ = run_request(url + "Api/Vehicles/getTrips", params=params)
-            response = json.loads(response_.content)["response"]
-            logger.info(
-                f"pulled {0 if response is None else len(response)} for car id {car.id} in period {start_month} to {end_month}"
-            )
-            if response is None:
-                continue
-            for trip in response:
-                start_location = (
-                    None
-                    if trip["startLocation"] not in address2id
-                    else address2id[trip["startLocation"]]
-                )
-                car_trips.append(
-                    Trips(
-                        **dict(
-                            id=trip["id"],
-                            car_id=car.id,
-                            distance=trip["distance"],
-                            start_time=datetime.datetime.fromisoformat(
-                                trip["startTimestamp"][:-5]
-                            ),
-                            end_time=datetime.datetime.fromisoformat(
-                                trip["endTimestamp"][:-5]
-                            ),
-                            start_latitude=trip["startLatitude"],
-                            start_longitude=trip["startLongitude"],
-                            end_latitude=trip["endLatitude"],
-                            end_longitude=trip["endLongitude"],
-                            start_location=start_location,
-                            driver_name=None,
-                        )
-                    )
-                )
-        if car_trips:
-            with session() as s:
-                s.add_all(car_trips)
-                s.commit()
-            logger.info(f"Saved {len(car_trips)} for {car.id}")
+        with Session.begin() as session:
+            save_vehicle(car_details, session, dmr_keys=dmr_keys)
 
 
 @cli.command()
@@ -636,30 +502,6 @@ def update_car(vehicle, saved_car):
         if value != saved_car[key]:
             return True
     return False
-
-
-def is_car_valid(car_dict):
-    validation_dict = car_dict.copy()
-    validation_dict["fuel"] = {"id": validation_dict.get("fuel", None)}
-    validation_dict["type"] = {"id": validation_dict.get("type", None)}
-    validation_dict["location"] = {"id": validation_dict.get("location", None)}
-    validation_dict["leasing_type"] = {"id": validation_dict.get("leasing_type", None)}
-    for key, value in car_dict.items():
-        if pd.isna(value):
-            validation_dict[key] = None
-    try:
-        Vehicle(**validation_dict)
-    except ValidationError as e:
-        logger.warning(
-            f"\n\n**************************************\n"
-            f"Could not validate vehicle {car_dict['id']}\n"
-            f"{e}\n"
-            f"{car_dict}\n\n"
-            f"Not saving/updating the vehicle\n"
-            f"**************************************\n\n"
-        )
-        return False
-    return True
 
 
 def compare_new_old(car_dict, saved_dict):

--- a/fleetmanager/extractors/gamfleet/updatedb.py
+++ b/fleetmanager/extractors/gamfleet/updatedb.py
@@ -17,20 +17,23 @@ from fleetmanager.data_access import (
     Cars,
     RoundTrips,
     RoundTripSegments,
-    FuelTypes,
-    VehicleTypes,
-    LeasingTypes,
     SimulationSettings
 )
 from fleetmanager.extractors.mileagebook.updatedb import CarModel
 from fleetmanager.extractors.skyhost.updatedb import summer_times, winter_times
 
-from fleetmanager.extractors.util import extract_plate, get_allowed_starts_with_additions
+from fleetmanager.extractors.util import (
+    extract_plate,
+    get_allowed_starts_with_additions,
+    get_plate_info_from_api,
+    save_vehicle,
+    vehicle_needs_dmr_data,
+)
 from fleetmanager.logging import logging
 from fleetmanager.model.roundtripaggregator import aggregating_score as score, sanitise_for_overlaps
 from fleetmanager.model.roundtripaggregator import aggregator, process_car_roundtrips
 
-from fleetmanager.extractors.gamfleet.util import run_request, get_splate_info_from_api, get_logs, format_trip_logs
+from fleetmanager.extractors.gamfleet.util import run_request, get_logs, format_trip_logs
 
 logger = logging.getLogger(__name__)
 
@@ -185,14 +188,13 @@ def set_vehicles(ctx, description_fields=None):
             continue
 
         # only need to collect this again if we have no information on the vehicle
-        if (saved_vehicle is None) or (pd.isna(saved_vehicle.wltp_fossil) and pd.isna(saved_vehicle.wltp_fossil) and pd.isna(saved_vehicle.make)):
+        if vehicle_needs_dmr_data(saved_vehicle):
             plate = extract_plate(vehicle.get("LicensePlate").replace(" ", ""))
             plate = plate if plate else extract_plate(vehicle.get("SecondLicensePlate").replace(" ", ""))
             vehicle_information = {}
             if plate:
-                vehicle_information = get_splate_info_from_api(plate)
+                vehicle_information = get_plate_info_from_api(plate)
 
-            # now we should compare and check if update necessary or we should save cause it's new
             drivkraft = vehicle_information.get("drivkraft")
             drivkraft = None if drivkraft is None else drivkraft.lower()
             motor_register_car = {
@@ -216,97 +218,27 @@ def set_vehicles(ctx, description_fields=None):
                 ),
             }
 
-            # determine if it's worth saving, should location flagged?
             if motor_register_car.get("location") is None:
                 logger.info(f"New district {district_name} not saved")
 
-            if motor_register_car.get("location") is not None:
-                motor_register_car["location_obj"] = sess.get(
-                    AllowedStarts, motor_register_car.get("location")
-                )
-            if motor_register_car.get("fuel") is not None:
-                motor_register_car["fuel_obj"] = sess.get(FuelTypes, motor_register_car.get("fuel"))
-
-            if motor_register_car.get("leasing_type") is not None and motor_register_car.get("end_leasing") is not None:
-                motor_register_car["leasing_type_obj"] = sess.get(
-                    LeasingTypes, motor_register_car.get("leasing_type")
-                )
-            if motor_register_car.get("type") is not None:
-                motor_register_car["type_obj"] = sess.get(VehicleTypes, motor_register_car.get("type"))
-
-            if motor_register_car.get("location") is not None:
-                motor_register_car["location_obj"] = sess.get(AllowedStarts, motor_register_car.get("location"))
-
+            # reset type/fuel when no wltp — a vehicle can't be used without both
             if (
-                    motor_register_car.get("type") is not None
-                    and motor_register_car.get("wltp_fossil") is None
-                    and motor_register_car.get("wltp_el") is None
+                motor_register_car.get("type") is not None
+                and motor_register_car.get("wltp_fossil") is None
+                and motor_register_car.get("wltp_el") is None
             ):
-                # reset the type and fuel if wltp is not set, cars can't be validated without type and wltp entered.
                 motor_register_car["type"] = None
-                motor_register_car["type_obj"] = None
                 motor_register_car["fuel"] = None
-                motor_register_car["fuel_obj"] = None
 
-
-            if saved_vehicle is None:
-                # new car, just save it
-                sess.add(Cars(**motor_register_car))
-                sess.commit()
-
-            else:
-                # compare values
-                comparable_keys = [
-                    key for key in motor_register_car.keys() if key in saved_columns
-                ]
-
-                if any(
-                        [
-                            saved_vehicle.get(key) != motor_register_car.get(key)
-                            for key in comparable_keys
-                            if pd.isna(motor_register_car.get(key)) is False
-                        ]
-                ):
-                    db_car = sess.get(Cars, vehicle_id)
-
-                    complex_types = {
-                        "location": AllowedStarts,
-                        "fuel": FuelTypes,
-                        "type": VehicleTypes,
-                        "leasing_type": LeasingTypes,
-                    }
-                    for key in comparable_keys:
-                        if key == 'leasing_type' and motor_register_car.get("end_leasing") is None:
-                            continue
-                        new_value = motor_register_car.get(key)
-                        if (
-                                saved_vehicle.get(key) != new_value
-                                and pd.isna(new_value) is False
-                                and new_value != 0
-                        ):
-                            # something changed
-                            setattr(db_car, key, new_value)
-                            if key in complex_types:
-                                setattr(
-                                    db_car,
-                                    f"{key}_obj",
-                                    sess.get(complex_types[key], new_value),
-                                )
-                    sess.commit()
+            dmr_keys = ["make", "model", "range", "wltp_fossil", "wltp_el", "type", "fuel", "end_leasing"]
+            save_vehicle(motor_register_car, sess, dmr_keys=dmr_keys)
         else:
-            # here we only need to check if the location has changed
-            saved_location = sess.get(AllowedStarts, saved_vehicle.location)
-            if saved_location.address != district_name:
-                new_location = sess.query(AllowedStarts).filter(AllowedStarts.address == district_name).first()
-                if new_location is None:
-                    logger.info(f"New district name does not exist: {district_name}, skipping update on vehicle id {vehicle_id}")
-                    continue
-
-                db_car = sess.get(Cars, vehicle_id)
-                db_car.location = new_location.id
-                db_car.location_obj = new_location
-                sess.commit()
+            # vehicle has full data — only keep the location in sync
+            new_location = sess.query(AllowedStarts).filter(AllowedStarts.address == district_name).first()
+            if new_location is None:
+                logger.info(f"New district name does not exist: {district_name}, skipping update on vehicle id {vehicle_id}")
                 continue
+            save_vehicle({"id": vehicle_id, "location": new_location.id}, sess)
 
 
 @cli.command()

--- a/fleetmanager/extractors/gamfleet/util.py
+++ b/fleetmanager/extractors/gamfleet/util.py
@@ -1,6 +1,5 @@
 import requests
 from time import sleep
-import pandas as pd
 import numpy as np
 from datetime import datetime, timedelta
 
@@ -8,60 +7,6 @@ from fleetmanager.logging import logging
 
 
 logger = logging.getLogger(__name__)
-
-
-def load_dmr_request(plate: str):
-    url = f"https://www.tjekbil.dk/api/v3/dmr/regnr/{plate}"
-    headers = {
-        "User-Agent": "FleetOptimiser/1.0"
-    }
-    results = requests.get(url, headers=headers)
-
-    if results.status_code != 200:
-        results = {}
-    else:
-        results = results.json()
-
-    return results
-
-
-def get_splate_info_from_api(plate: str) -> dict:
-    result = {}
-    result = load_dmr_request(plate)
-    basic = result.get("basic", {})
-
-    car_data = {}
-
-    drivkraft = None
-    if "drivkraftTypeNavn" in basic:
-        drivkraft = basic.get("drivkraftTypeNavn")
-        drivkraft = None if drivkraft is None else drivkraft.lower()
-        car_data["drivkraft"] = drivkraft
-    if drivkraft == 'el':
-        wltp_el = basic.get("motorElektriskForbrug")
-        if pd.isna(wltp_el):
-            wltp_el = basic.get("motorElektriskForbrugMaalt")
-        car_data["el_faktisk_forbrug"] = wltp_el
-        try:
-            car_data["elektrisk_rækkevidde"] = result.get("extended", {}).get("techical", {}).get("elektriskRaekkevidde") # there's a spelling mistake in response technical = techical
-        except AttributeError:
-            retry = 1
-            max_retry = 4
-            while max_retry > retry:
-                result = load_dmr_request(plate)
-                retry += 1
-                if pd.isna(result.get("extended", {})):
-                    continue
-                else:
-                    result.get("extended", {}).get("techical", {}).get(
-                        "elektriskRaekkevidde")  # there's a spelling mistake in response technical = techical
-                    break
-    else:
-        car_data["kml"] = basic.get("motorKmPerLiter")
-    car_data["leasing_end"] = None if basic.get("leasingGyldigTil") is None else datetime.fromisoformat(basic.get("leasingGyldigTil"))
-    car_data["make"] = basic.get("maerkeTypeNavn")
-    car_data["model"] = " ".join([basic.get("modelTypeNavn", ""), basic.get("variantTypeNavn", "")]).strip()
-    return car_data
 
 
 def run_request(uri, params, headers=None):
@@ -146,3 +91,4 @@ def format_trip_logs(trips: list, vehicle_id: int):
     return trips[
         ["id", "car_id", "start_time", "end_time", "start_latitude", "start_longitude", "end_latitude", "end_longitude",
          "distance"]].to_dict("records")
+

--- a/fleetmanager/extractors/mileagebook/updatedb.py
+++ b/fleetmanager/extractors/mileagebook/updatedb.py
@@ -17,10 +17,7 @@ from fleetmanager.api.location.schemas import AllowedStart as AllowedStartSchema
 from fleetmanager.data_access import (
     AllowedStarts,
     Cars,
-    FuelTypes,
-    LeasingTypes,
     RoundTrips,
-    VehicleTypes,
     SimulationSettings,
     RoundTripSegments,
 )
@@ -29,7 +26,7 @@ from fleetmanager.extractors.skyhost.updatedb import (
     summer_times,
     winter_times,
 )
-from fleetmanager.extractors.util import get_latlon_address, get_allowed_starts_with_additions
+from fleetmanager.extractors.util import get_allowed_starts_with_additions, get_latlon_address, save_vehicle
 from fleetmanager.logging import logging
 from fleetmanager.model.roundtripaggregator import aggregating_score as score
 from fleetmanager.model.roundtripaggregator import (
@@ -218,7 +215,6 @@ def set_vehicles(ctx, description_fields=None):
         description_fields = []
 
     saved_vehicles = pd.read_sql(Query(Cars).statement, engine)
-    saved_columns = saved_vehicles.columns
 
     MileageBookMappings.locations = {
         location.address: location.id for location in sess.query(AllowedStarts)
@@ -269,17 +265,9 @@ def set_vehicles(ctx, description_fields=None):
             "description": _create_description(vehicle, description_fields),
         }
 
-        if current_car.get("location") is not None:
-            current_car["location_obj"] = sess.get(
-                AllowedStarts, current_car.get("location")
-            )
         if current_car.get("make") is None or current_car.get("make") == "":
             current_car["make"] = vehicle.get("Name")
-        if (
-            # current_car.get("fuel") == "Ikke sat" and
-            "cykel"
-            in current_car.get("make", "").lower()
-        ):
+        if "cykel" in current_car.get("make", "").lower():
             current_car["fuel"] = 10
         if (
             current_car.get("fuel") not in ["Ikke sat", None, "bike"]
@@ -291,86 +279,25 @@ def set_vehicles(ctx, description_fields=None):
                 current_car["wltp_fossil"] = vehicle.get("FuelConsumption")
         if current_car.get("fuel") == "Ikke sat":
             current_car["fuel"] = None
-        if current_car.get("fuel") is not None:
-            current_car["fuel_obj"] = sess.get(FuelTypes, current_car.get("fuel"))
-        if (
-            current_car.get("leasing_type") is not None
-            and current_car.get("end_leasing") is not None
-        ):
-            current_car["leasing_type_obj"] = sess.get(
-                LeasingTypes, current_car.get("leasing_type")
-            )
-        if current_car.get("type") is not None:
-            current_car["type_obj"] = sess.get(VehicleTypes, current_car.get("type"))
         if current_car.get("end_leasing") is not None:
-            current_car["end_leasing"] = datetime.fromisoformat(
-                current_car.get("end_leasing")
-            )
+            current_car["end_leasing"] = datetime.fromisoformat(current_car.get("end_leasing"))
         if current_car.get("start_leasing") is not None:
-            current_car["start_leasing"] = datetime.fromisoformat(
-                current_car.get("start_leasing")
-            )
+            current_car["start_leasing"] = datetime.fromisoformat(current_car.get("start_leasing"))
+
+        if current_car.get("end_leasing") is None:
+            current_car["leasing_type"] = None
 
         if (
             current_car.get("type") is not None
             and current_car.get("wltp_fossil") is None
             and current_car.get("wltp_el") is None
         ):
-            # reset the type and fuel if wltp is not set, cars can't be validated without type and wltp entered.
             current_car["type"] = None
-            current_car["type_obj"] = None
             current_car["fuel"] = None
-            current_car["fuel_obj"] = None
 
-        if change_status_disabled:
-            current_car["disabled"] = 1
-        else:
-            current_car["disabled"] = 0
+        current_car["disabled"] = 1 if change_status_disabled else 0
 
-        if car_id in saved_vehicles.id.values:
-            # logic for updating values for known vehicles
-            saved_vehicle = (
-                saved_vehicles[saved_vehicles.id == car_id].iloc[0].to_dict()
-            )
-            comparable_keys = [
-                key for key in current_car.keys() if key in saved_columns
-            ] + ["disabled"]
-
-            if any(
-                [
-                    saved_vehicle.get(key) != current_car.get(key)
-                    for key in comparable_keys
-                    if pd.isna(current_car.get(key)) is False
-                ]
-            ):
-                db_car = sess.get(Cars, car_id)
-                complex_types = {
-                    "location": AllowedStarts,
-                    "fuel": FuelTypes,
-                    "type": VehicleTypes,
-                    "leasing_type": LeasingTypes,
-                }
-                for key in comparable_keys:
-                    if key == "leasing_type" and current_car.get("end_leasing") is None:
-                        continue
-                    new_value = current_car.get(key)
-                    if (
-                        saved_vehicle.get(key) != new_value
-                        and pd.isna(new_value) is False
-                        and (new_value != 0 or key == "disabled")
-                    ):
-                        # something changed
-                        setattr(db_car, key, new_value)
-                        if key in complex_types:
-                            setattr(
-                                db_car,
-                                f"{key}_obj",
-                                sess.get(complex_types[key], new_value),
-                            )
-                sess.commit()
-        else:
-            sess.add(Cars(**current_car))
-            sess.commit()
+        save_vehicle(current_car, sess)
 
 
 @cli.command()

--- a/fleetmanager/extractors/puma/updatedb.py
+++ b/fleetmanager/extractors/puma/updatedb.py
@@ -16,12 +16,9 @@ from fleetmanager.api.location.schemas import AllowedStart as AllowedStartSchema
 from fleetmanager.data_access import (
     AllowedStarts,
     Cars,
-    FuelTypes,
-    LeasingTypes,
     RoundTrips,
     RoundTripSegments,
     SimulationSettings,
-    VehicleTypes,
 )
 from fleetmanager.extractors.puma.pumaschema import Data, Materiels
 from fleetmanager.extractors.skyhost.updatedb import (
@@ -31,9 +28,12 @@ from fleetmanager.extractors.skyhost.updatedb import (
 )
 from fleetmanager.extractors.util import (
     extract_plate,
+    get_allowed_starts_with_additions,
     get_latlon_address,
+    get_plate_info_from_api,
     logs_to_trips,
-    to_list, get_plate_info_from_api, get_allowed_starts_with_additions,
+    save_vehicle,
+    to_list,
 )
 from fleetmanager.logging import logging
 from fleetmanager.model.roundtripaggregator import (
@@ -176,7 +176,7 @@ def set_vehicles(ctx, description_fields=None):
             loop = asyncio.get_event_loop()
             logger.info(f"looking for {vehicle.registreringsnummer}")
             try:
-                vehicle_attributes = loop.run_until_complete(get_plate_info_from_api(plate))
+                vehicle_attributes = get_plate_info_from_api(plate)
             except Exception as e:
                 logger.info(f"finding plate info from plate failed: {plate}, {e}")
                 continue
@@ -188,38 +188,17 @@ def set_vehicles(ctx, description_fields=None):
                 "plate": plate,
                 "make": vehicle_attributes.get("make"),
                 "model": vehicle_attributes.get("model"),
-                "wltp_fossil": None
-                if drivkraft == "el"
-                else vehicle_attributes.get("kml"),
+                "wltp_fossil": None if drivkraft == "el" else vehicle_attributes.get("kml"),
                 "wltp_el": vehicle_attributes.get("el_faktisk_forbrug")
                 if "el_faktisk_forbrug" in vehicle_attributes
                 else vehicle_attributes.get("elektrisk_forbrug"),
                 "type": vehicle_type.get(drivkraft),
-                "type_obj": None
-                if drivkraft is None
-                else session.get(VehicleTypes, vehicle_type.get(drivkraft)),
                 "fuel": fuel.get(drivkraft),
-                "fuel_obj": None
-                if drivkraft is None
-                else session.get(FuelTypes, fuel.get(drivkraft)),
                 "range": vehicle_attributes.get("elektrisk_rækkevidde"),
                 "leasing_type": 3,
                 "department": vehicle.forvaltning,
-                "leasing_type_obj": session.get(LeasingTypes, 3),
                 "location": int(
-                    known_starts[
-                        known_starts.address == vehicle.placeringsadresse
-                    ].id.values[0]
-                ),
-                "location_obj": None
-                if vehicle.placeringsadresse is None
-                else session.get(
-                    AllowedStarts,
-                    int(
-                        known_starts[
-                            known_starts.address == vehicle.placeringsadresse
-                        ].id.values[0]
-                    ),
+                    known_starts[known_starts.address == vehicle.placeringsadresse].id.values[0]
                 ),
                 "description": " ".join(
                     [
@@ -230,8 +209,7 @@ def set_vehicles(ctx, description_fields=None):
                 ),
             }
 
-            session.add(Cars(**new_car_object))
-            session.commit()
+            save_vehicle(new_car_object, session)
 
 
 @cli.command()

--- a/fleetmanager/extractors/skyhost/updatedb.py
+++ b/fleetmanager/extractors/skyhost/updatedb.py
@@ -18,9 +18,14 @@ from fleetmanager.data_access import (
     Trips
 )
 from fleetmanager.data_access.dbschema import RoundTripSegments
-from fleetmanager.extractors.fleetcomplete.updatedb import is_car_valid
-from fleetmanager.extractors.gamfleet.util import get_splate_info_from_api
-from fleetmanager.extractors.util import get_allowed_starts_with_additions
+from fleetmanager.extractors.util import (
+    apply_dmr_data,
+    get_allowed_starts_with_additions,
+    get_plate_info_from_api,
+    is_car_valid,
+    save_vehicle,
+    vehicle_needs_dmr_data,
+)
 from fleetmanager.logging import logging
 from fleetmanager.model.roundtripaggregator import (
     aggregator,
@@ -417,36 +422,16 @@ def set_trackers_v2(ctx, description_fields=None):
                 description_plate_pattern = re.search(r"\w{2}\d{5}", vehicle_from_skyhost.get("description", ""))
                 plate = None if description_plate_pattern is None else description_plate_pattern.group()
 
-            keys_updated_from_dmr_info = []
             vehicle_dmr_info = {}
-            if make is None or model is None and plate:
-                vehicle_dmr_info = get_splate_info_from_api(plate)
+            if plate and vehicle_needs_dmr_data(car_db[0] if known_car else None):
+                vehicle_dmr_info = get_plate_info_from_api(plate)
                 sleep(1)
-                make = vehicle_dmr_info.get("make", make)
-                model = vehicle_dmr_info.get("model", model)
-                keys_updated_from_dmr_info += ["make", "model"]
 
-            v_type, keys_updated_from_dmr_info = get_vehicle_type(
-                vehicle_details.get("details", {}).get("environmentalDetails"),
-                dmr_info=vehicle_dmr_info,
-                keys_updated_from_dmr=keys_updated_from_dmr_info
-            )
-            fuel, keys_updated_from_dmr_info = get_vehicle_fuel(
-                vehicle_details.get("details", {}).get("environmentalDetails"),
-                dmr_info=vehicle_dmr_info,
-                keys_updated_from_dmr=keys_updated_from_dmr_info
-            )
-            wltp_el, keys_updated_from_dmr_info = get_vehicle_wltp(
-                vehicle_details.get("details", {}),
-                "el",
-                dmr_info=vehicle_dmr_info,
-                keys_updated_from_dmr=keys_updated_from_dmr_info
-            )
-            wltp_fossil, keys_updated_from_dmr_info = get_vehicle_wltp(
-                vehicle_details.get("details", {}), "fossil",
-                dmr_info=vehicle_dmr_info,
-                keys_updated_from_dmr=keys_updated_from_dmr_info
-            )
+            env_details = vehicle_details.get("details", {}).get("environmentalDetails")
+            v_type = get_vehicle_type(env_details)
+            fuel = get_vehicle_fuel(env_details)
+            wltp_el = get_vehicle_wltp(vehicle_details.get("details", {}), "el")
+            wltp_fossil = get_vehicle_wltp(vehicle_details.get("details", {}), "fossil")
             range_km = get_electrical_range(vehicle_details.get("details"))
             car = dict(
                 id=int(id_),
@@ -472,6 +457,8 @@ def set_trackers_v2(ctx, description_fields=None):
                 range=None if range_km is None else round(range_km, 2),
             )
 
+            dmr_keys = apply_dmr_data(car, vehicle_dmr_info)
+
             if "arkiveret" in vehicle_details.get("department", {}).get("name", "").lower():
                 car["disabled"] = 1
             elif ctx.obj["update_vehicle_location"] and (known_location := get_location_id(vehicle_details.get("department"), session)):
@@ -481,12 +468,7 @@ def set_trackers_v2(ctx, description_fields=None):
             if not is_car_valid(car):
                 continue
 
-            if known_car:
-                # update if values are different and not none
-                update_car(car, session, keys_updated_from_dmr_info)
-            else:
-                # insert unknown valid car
-                insert_car(car, session)
+            save_vehicle(car, session, dmr_keys=dmr_keys)
 
 
 @cli.command()

--- a/fleetmanager/extractors/skyhost/util.py
+++ b/fleetmanager/extractors/skyhost/util.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone, timedelta, date
 from time import sleep
 from typing import Literal, TypedDict
 import pytz
-from fleetmanager.data_access import LeasingTypes, FuelTypes, VehicleTypes, AllowedStarts, Cars
+from fleetmanager.data_access import AllowedStarts
 from fleetmanager.logging import logging
 
 
@@ -37,13 +37,6 @@ winter_times = [
     date(2027, 10, 31),
 ]
 anhour = timedelta(hours=1)
-
-back_ref_types = {
-    "leasing_type": LeasingTypes,
-    "fuel": FuelTypes,
-    "type": VehicleTypes,
-    "location": AllowedStarts
-}
 
 
 class MileageTripResponseError(Exception):
@@ -275,40 +268,6 @@ def date_iter(start_date, end_date, week_period=24):
         last_start = start_date
 
 
-def update_car(current_car: dict, session: Session, dmr_attributes: list):
-    saved_car = session.get(Cars, current_car.get("id"))
-    for key, value in current_car.items():
-        if pd.isna(value):
-            continue
-
-        if getattr(saved_car, key) == value:
-            continue
-
-        if type(value) == str and len(value) == 0:
-            continue
-
-        if key in dmr_attributes and getattr(saved_car, key) is not None:
-            # we don't want to write DMR attributes if it's been changed elsewhere
-            continue
-
-        if key in back_ref_types.keys():
-            setattr(saved_car, f"{key}_obj", session.get(back_ref_types[key], value))
-
-        setattr(saved_car, key, value)
-        session.commit()
-
-
-def insert_car(current_car: dict, session: Session):
-    for key, ref_type in back_ref_types.items():
-        if back_ref_value := current_car.get(key):
-            current_car.update(
-                {f"{key}_obj": session.get(ref_type, back_ref_value)}
-            )
-
-    session.add(Cars(**current_car))
-    session.commit()
-
-
 def get_electrical_range(details: details_object | None):
     vehicle_range = None
     if (
@@ -348,9 +307,7 @@ def calcluate_wh_km_from_range(useabililty_details: useabilityDetails_object | N
     return wh_pr_km
 
 
-def get_vehicle_wltp(details: details_object | None, wltp_key: Literal["el", "fossil"] = "el", dmr_info: dict = None, keys_updated_from_dmr: list = None):
-    if keys_updated_from_dmr is None:
-        keys_updated_from_dmr = []
+def get_vehicle_wltp(details: details_object | None, wltp_key: Literal["el", "fossil"] = "el"):
     if details is None:
         return None
     env_details = details.get("environmentalDetails", {})
@@ -383,72 +340,31 @@ def get_vehicle_wltp(details: details_object | None, wltp_key: Literal["el", "fo
         wltp_function = unit_to_function[unit]
         wltp = wltp_function(float(env_details.get("fuelConsumption")))
 
-    if wltp is None and dmr_info:
-        drivkraft = dmr_info.get("drivkraft")
-        if drivkraft in ["benzin", "diesel"] and wltp_key == 'fossil':
-            keys_updated_from_dmr.append("wltp_fossil")
-            return dmr_info.get("kml"), keys_updated_from_dmr
-        elif drivkraft in ["el"] and wltp_key == 'el':
-            keys_updated_from_dmr.append("wltp_el")
-            return dmr_info.get("el_faktisk_forbrug"), keys_updated_from_dmr
-
-    return wltp, keys_updated_from_dmr
+    return wltp
 
 
-def get_vehicle_type(env_details: env_details_object | None, dmr_info: dict = None, keys_updated_from_dmr: list = None):
-    if keys_updated_from_dmr is None:
-        keys_updated_from_dmr = []
-    if dmr_info is None:
-        dmr_info = {}
+def get_vehicle_type(env_details: env_details_object | None):
     fuelType_to_vehicleType = {
         "Petrol": 4,
         "Diesel": 4,
         "Electric": 3,
         "Hydrogen": None
     }
-    dmr_to_type = {
-        "diesel": 4,
-        "benzin": 4,
-        "el": 3,
-        None: None
-    }
-    vehicle_type = None
     if env_details is None or env_details.get("fuelType") is None:
-        drivkraft = dmr_info.get("drivkraft")
-        if drivkraft in dmr_to_type:
-            vehicle_type = dmr_to_type[drivkraft]
-            keys_updated_from_dmr.append("type")
-        return vehicle_type, keys_updated_from_dmr
-    vehicle_type = fuelType_to_vehicleType[env_details.get("fuelType")]
-    return vehicle_type, keys_updated_from_dmr
+        return None
+    return fuelType_to_vehicleType[env_details.get("fuelType")]
 
 
-def get_vehicle_fuel(env_details: env_details_object | None, dmr_info: dict = None, keys_updated_from_dmr: list = None):
-    if keys_updated_from_dmr is None:
-        keys_updated_from_dmr = []
-    if dmr_info is None:
-        dmr_info = {}
+def get_vehicle_fuel(env_details: env_details_object | None):
     fuelType_to_vehicleType = {
         "Petrol": 1,
         "Diesel": 2,
         "Electric": 3,
         "Hydrogen": None
     }
-    dmr_to_type = {
-        "diesel": 2,
-        "benzin": 1,
-        "el": 3,
-        None: None
-    }
-    fuel_type = None
     if env_details is None or env_details.get("fuelType") is None:
-        drivkraft = dmr_info.get("drivkraft")
-        if drivkraft in dmr_to_type:
-            fuel_type = dmr_to_type[drivkraft]
-            keys_updated_from_dmr.append("fuel")
-        return fuel_type, keys_updated_from_dmr
-    fuel_type = fuelType_to_vehicleType[env_details.get("fuelType")]
-    return fuel_type, keys_updated_from_dmr
+        return None
+    return fuelType_to_vehicleType[env_details.get("fuelType")]
 
 
 def get_leasing_date(leasing: leasing_object | None, date_key: Literal["startDate", "endDate"] = "endDate"):

--- a/fleetmanager/extractors/util.py
+++ b/fleetmanager/extractors/util.py
@@ -1,21 +1,28 @@
 import ast
-import asyncio
-import json
 import urllib.parse
 
+from datetime import datetime
 import pandas as pd
 import regex as re
 import requests
+from pydantic import ValidationError
 from sqlalchemy.orm import Session, selectinload
-from tenacity import retry, wait_random_exponential, stop_after_attempt
 
-from fleetmanager.data_access import AllowedStarts
+from fleetmanager.api.configuration.schemas import Vehicle
+from fleetmanager.data_access import AllowedStarts, Cars, FuelTypes, LeasingTypes, VehicleTypes
 from fleetmanager.logging import logging
 from fleetmanager.model.roundtripaggregator import calc_distance
-import httpx
 
 
 logger = logging.getLogger(__name__)
+
+
+BACK_REF_TYPES: dict = {
+    "leasing_type": LeasingTypes,
+    "fuel": FuelTypes,
+    "type": VehicleTypes,
+    "location": AllowedStarts,
+}
 
 
 def get_values(original_source: str) -> dict:
@@ -88,79 +95,6 @@ def find_in_settings(settings, find_key):
             for k, v in value.items():
                 if k == find_key:
                     return v
-
-
-@retry(wait=wait_random_exponential(min=1, max=20), stop=stop_after_attempt(3))
-async def load_dmr_request(plate: str):
-    url = f"https://www.tjekbil.dk/api/v3/dmr/regnr/{plate}"
-
-    completed = False
-    retries = 3
-    retry = 0
-    while not completed:
-        async with httpx.AsyncClient() as client:
-            try:
-                response = await client.get(url)
-                result = response.content.decode()
-            except httpx.ReadTimeout as e:
-                retry += 1
-                if retry < retries:
-                    await asyncio.sleep(3 * retry)
-                else:
-                    raise e
-
-    return json.loads(result)
-
-
-async def get_plate_info_from_api(plate: str) -> dict:
-    result = {}
-    task = asyncio.create_task(load_dmr_request(plate))
-    done, pending = await asyncio.wait({task}, timeout=60)
-    if task in done:
-        try:
-            result = task.result()
-            if "basic" not in result:
-                return {}
-        except asyncio.InvalidStateError as e:
-            logger.info(f"something went wrong {plate}, \n{e}")
-            return {}
-    for p in pending:
-        logger.info(f"timeout for plate {plate}")
-        p.cancel()
-    basic = result.get("basic", {})
-
-    car_data = {}
-
-    drivkraft = None
-    if "drivkraftTypeNavn" in basic:
-        drivkraft = basic.get("drivkraftTypeNavn")
-        drivkraft = None if drivkraft is None else drivkraft.lower()
-        car_data["drivkraft"] = drivkraft
-    if drivkraft == 'el':
-        wltp_el = basic.get("motorElektriskForbrug")
-        if pd.isna(wltp_el):
-            wltp_el = basic.get("motorElektriskForbrugMaalt")
-        car_data["el_faktisk_forbrug"] = wltp_el
-        try:
-            car_data["elektrisk_rækkevidde"] = result.get("extended", {}).get("techical", {}).get("elektriskRaekkevidde") # there's a spelling mistake in response technical = techical
-        except AttributeError:
-            retry = 1
-            max_retry = 4
-            while max_retry > retry:
-                result = await load_dmr_request(plate)
-                retry += 1
-                if pd.isna(result.get("extended", {})):
-                    continue
-                else:
-                    result.get("extended", {}).get("techical", {}).get(
-                        "elektriskRaekkevidde")  # there's a spelling mistake in response technical = techical
-                    break
-    else:
-        car_data["kml"] = basic.get("motorKmPerLiter")
-
-    car_data["make"] = basic.get("maerkeTypeNavn")
-    car_data["model"] = " ".join([basic.get("modelTypeNavn", ""), basic.get("variantTypeNavn", "")]).strip()
-    return car_data
 
 
 def get_latlon_address(address):
@@ -449,3 +383,207 @@ def get_allowed_starts_with_additions(
                 }
             )
     return allowed_starts
+
+def vehicle_needs_dmr_data(saved_vehicle) -> bool:
+    """
+    returns true if the vehicle is missing key attributes that triggers a dmr lookup.
+    If make, model, type and wltp (fossil or el) are all present, we skip dmr
+    to avoid overriding data set directly via integration or user.
+    """
+    if saved_vehicle is None:
+        return True
+
+    def get_val(key):
+        if hasattr(saved_vehicle, "get"):
+            val = saved_vehicle.get(key)
+        else:
+            val = getattr(saved_vehicle, key, None)
+        try:
+            return None if pd.isna(val) else val
+        except (TypeError, ValueError):
+            return val
+
+    has_make = get_val("make") is not None
+    has_model = get_val("model") is not None
+    has_type = get_val("type") is not None
+    has_wltp = get_val("wltp_fossil") is not None or get_val("wltp_el") is not None
+
+    return not (has_make and has_model and has_type and has_wltp)
+
+
+def save_vehicle(car_dict: dict, session: Session, dmr_keys: list[str] = None):
+    """
+    Insert a new Cars record or update an existing one.
+
+    car_dict should be a flat dict keyed by Cars column names. Any pre-built
+    _obj relationship keys are ignored and resolved from the FK integer values.
+
+    dmr_keys lists keys whose values came from the api.
+    Those keys will not overwrite an existing non-null value in the db, so data
+    set directly via integration or by user is never silently overwritten.
+    """
+    if dmr_keys is None:
+        dmr_keys = []
+
+    car_id = car_dict.get("id")
+    saved_car = session.get(Cars, car_id)
+    car_columns = set(Cars.__table__.columns.keys())
+
+    if saved_car is None:
+        insert_dict = {k: v for k, v in car_dict.items() if k in car_columns}
+        for key, ref_type in BACK_REF_TYPES.items():
+            if (val := insert_dict.get(key)) is not None:
+                insert_dict[f"{key}_obj"] = session.get(ref_type, val)
+        session.add(Cars(**insert_dict))
+        session.commit()
+        logger.info(f"Inserted new vehicle id={car_id}")
+        return
+
+    for key, value in car_dict.items():
+        if key not in car_columns or key == "id":
+            continue
+        try:
+            if pd.isna(value):
+                continue
+        except (TypeError, ValueError):
+            pass
+        if isinstance(value, str) and not value:
+            continue
+        if value == 0 and key != "disabled":
+            continue
+        if key in dmr_keys and getattr(saved_car, key, None) is not None:
+            continue
+        if getattr(saved_car, key, None) == value:
+            continue
+        setattr(saved_car, key, value)
+        if key in BACK_REF_TYPES:
+            setattr(saved_car, f"{key}_obj", session.get(BACK_REF_TYPES[key], value))
+
+    session.commit()
+
+
+def apply_dmr_data(car_dict: dict, dmr_info: dict) -> list[str]:
+    """
+    Fill missing fields in car_dict from dmr data.
+
+    Only sets a field if it is currently None in car_dict. Returns the list
+    of keys that were set, which should be passed as dmr_keys to save_vehicle
+    so the same protection applies at the db level.
+    """
+    if not dmr_info:
+        return []
+
+    dmr_keys = []
+    drivkraft = dmr_info.get("drivkraft")
+    drivkraft_to_fuel = {"benzin": 1, "diesel": 2, "el": 3}
+    drivkraft_to_type = {"benzin": 4, "diesel": 4, "el": 3}
+
+    def set_if_missing(key, value):
+        if car_dict.get(key) is None and value is not None:
+            car_dict[key] = value
+            dmr_keys.append(key)
+
+    set_if_missing("make", dmr_info.get("make"))
+    set_if_missing("model", dmr_info.get("model"))
+    set_if_missing("fuel", drivkraft_to_fuel.get(drivkraft))
+    set_if_missing("type", drivkraft_to_type.get(drivkraft))
+
+    if car_dict.get("wltp_fossil") is None:
+        car_dict["wltp_fossil"] = None if drivkraft == "el" else dmr_info.get("kml")
+        dmr_keys.append("wltp_fossil")
+    if car_dict.get("wltp_el") is None:
+        el = (
+            dmr_info.get("el_faktisk_forbrug")
+            if "el_faktisk_forbrug" in dmr_info
+            else dmr_info.get("elektrisk_forbrug")
+        )
+        car_dict["wltp_el"] = el
+        dmr_keys.append("wltp_el")
+    if car_dict.get("range") is None:
+        car_dict["range"] = dmr_info.get("elektrisk_rækkevidde")
+        dmr_keys.append("range")
+    if car_dict.get("end_leasing") is None:
+        car_dict["end_leasing"] = dmr_info.get("leasing_end")
+        dmr_keys.append("end_leasing")
+
+    # type/fuel are only meaningful when there is wltp data to back them up
+    if (
+        car_dict.get("type") is not None
+        and car_dict.get("wltp_fossil") is None
+        and car_dict.get("wltp_el") is None
+    ):
+        car_dict["type"] = None
+        car_dict["fuel"] = None
+
+    return dmr_keys
+
+
+def is_car_valid(car_dict: dict) -> bool:
+    """
+    validate a car dict against the Vehicle pydantic schema.
+    logs a warning and returns False if validation fails.
+    """
+    validation_dict = car_dict.copy()
+    validation_dict["fuel"] = {"id": validation_dict.get("fuel")}
+    validation_dict["type"] = {"id": validation_dict.get("type")}
+    validation_dict["location"] = {"id": validation_dict.get("location")}
+    validation_dict["leasing_type"] = {"id": validation_dict.get("leasing_type")}
+    for key, value in car_dict.items():
+        try:
+            if pd.isna(value):
+                validation_dict[key] = None
+        except (TypeError, ValueError):
+            pass
+    try:
+        Vehicle(**validation_dict)
+    except ValidationError as e:
+        logger.warning(
+            f"\n\n**************************************\n"
+            f"Could not validate vehicle {car_dict.get('id')}\n"
+            f"{e}\n"
+            f"{car_dict}\n\n"
+            f"Not saving/updating the vehicle\n"
+            f"**************************************\n\n"
+        )
+        return False
+    return True
+
+
+def get_plate_info_from_api(plate: str) -> dict:
+    # "techical" is a typo in the API response (should be "technical")
+    _EL_RANGE_KEY = "elektriskRaekkevidde"
+
+    def _fetch():
+        url = f"https://www.tjekbil.dk/api/v3/dmr/regnr/{plate}"
+        r = requests.get(url, headers={"User-Agent": "FleetOptimiser/1.0"})
+        return r.json() if r.status_code == 200 else {}
+
+    result = _fetch()
+    basic = result.get("basic") or {}
+
+    drivkraft_raw = basic.get("drivkraftTypeNavn")
+    drivkraft = drivkraft_raw.lower() if drivkraft_raw else None
+    car_data: dict = {"drivkraft": drivkraft} if drivkraft else {}
+
+    if drivkraft == "el":
+        techical = None
+        for _ in range(4):
+            extended = result.get("extended")
+            if extended is not None:
+                techical = extended.get("techical") or {}
+                break
+            result = _fetch()
+        techical = techical or {}
+
+        wltp_el = basic.get("motorElektriskForbrug")
+        if pd.isna(wltp_el):
+            wltp_el = techical.get("motorElektriskForbrugMaalt")
+        car_data["el_faktisk_forbrug"] = wltp_el
+        car_data["elektrisk_rækkevidde"] = techical.get(_EL_RANGE_KEY)
+    else:
+        car_data["kml"] = basic.get("motorKmPerLiter")
+
+    car_data["leasing_end"] = datetime.fromisoformat(raw) if (raw := basic.get("leasingGyldigTil")) else None
+    car_data["make"] = basic.get("maerkeTypeNavn")
+    car_data["model"] = " ".join(filter(None, [basic.get("modelTypeNavn"), basic.get("variantTypeNavn")])).strip()
+    return car_data


### PR DESCRIPTION
Centralises vehicle save/update logic across all five extractors into a shared save_vehicle function in extractors/util.py. Consolidates dm lookup  (get_plate_info_from_api), validation (is_car_valid), and dmr enrichment (apply_dmr_data) the same way. 