### PR TITLE
Feature/separate external and internal ids 298

### DIFF
--- a/fleetmanager/api/configuration/schemas.py
+++ b/fleetmanager/api/configuration/schemas.py
@@ -82,7 +82,9 @@ class Vehicle(BaseModel):
     sleep: int | None = Field(
         example=5, description="Minimum hour rest pr. charge for electrical vehicles"
     )
-    id: int = Field(example=1, description="ID of the vehicle")
+    id: int | None = Field(example=1, description="ID of the vehicle")
+    external_id: str | None = Field(None, example=195291203, description="External id from the fleet system")
+    source: str | None = Field(None, example="skyhost", description="Which fleet system the vehicle came from")
     location: Location | None
     deleted: bool | None = Field(
         example=False,

--- a/fleetmanager/configuration/util.py
+++ b/fleetmanager/configuration/util.py
@@ -158,6 +158,11 @@ def update_single_vehicle(session: Session, vehicle: Vehicle, ignore_none_values
         return "the car id does not exist"
     for key, value in vehicle:
 
+        # id is the lookup key; external_id/source are owned by the extractors and
+        # must never be overwritten (or nulled) by a manual vehicle edit
+        if key in ("id", "external_id", "source"):
+            continue
+
         if ignore_none_values and (value is None) and (key not in accepted_none_values):
             continue
 
@@ -273,7 +278,7 @@ def get_single_vehicle(session: Session, vehicle_id: int):
 
 def create_single_vehicle(session: Session, vehicle: VehicleInput, test_vehicle: bool = True):
     """
-    Function to create a vehicle. If the vehicle id is less than "min_allowed_id", the id will be set to 1000000.
+    Function to create a vehicle.
     The selected location must exist and the vehicle itself pass validation on Vehicle class.
     """
     key_to_model = {
@@ -283,15 +288,9 @@ def create_single_vehicle(session: Session, vehicle: VehicleInput, test_vehicle:
         "location": AllowedStarts,
     }
 
-    min_allowed_id = 1000000
     locations = [a.id for a in session.query(AllowedStarts.id).all()]
-    max_id = session.query(func.max(Cars.id)).first()[0]
-    if max_id is None or max_id < min_allowed_id:
-        new_id = min_allowed_id
-    else:
-        new_id = max_id + 1
 
-    vehicle_entry = {"id": new_id}
+    vehicle_entry = {}
     for key, value in vehicle:
         if key in ("id", "name"):
             continue
@@ -313,7 +312,10 @@ def create_single_vehicle(session: Session, vehicle: VehicleInput, test_vehicle:
 
     # manually creating a vehicle implies no fleet management synchronisation hence mark as test_vehicle
     vehicle_entry["test_vehicle"] = test_vehicle
-    session.add(Cars(**vehicle_entry))
+    new_car = Cars(**vehicle_entry)
+    session.add(new_car)
+    session.flush()
+    new_id = new_car.id
     session.commit()
     return new_id
 

--- a/fleetmanager/data_access/dbschema.py
+++ b/fleetmanager/data_access/dbschema.py
@@ -117,7 +117,9 @@ class VehicleTypes(Base):
 
 class Cars(Base):
     __tablename__ = "cars"
-    id: Mapped[int] = mapped_column(primary_key=True, nullable=False)
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False, autoincrement=True, default=None)
+    external_id: Mapped[Optional[str]] = mapped_column(String(64), default=None)
+    source: Mapped[Optional[str]] = mapped_column(String(64), default=None)
     imei: Mapped[str] = mapped_column(String(20), nullable=True, default=None)
     plate: Mapped[Optional[str]] = mapped_column(String(128), default=None)
     make: Mapped[Optional[str]] = mapped_column(String(128), default=None)

--- a/fleetmanager/extractors/clevertrack/updatedb.py
+++ b/fleetmanager/extractors/clevertrack/updatedb.py
@@ -122,14 +122,15 @@ def set_vehicles(ctx, description_fields=None):
         # plate is not seen before, add to database
         # if plate not in saved_vehicles.plate.tolist():
         if saved_vehicle.empty:
-            session.add(Cars(id=vid, plate=plate, imei=imei, description=description))
+            session.add(Cars(external_id=str(vid), source="clevertrack", plate=plate, imei=imei, description=description))
             # session.commit() ----
             continue
 
         # plate already exist in data
         saved_vehicle = saved_vehicle.iloc[0]
         if (
-            (str(saved_vehicle.id) == vid)
+            (str(saved_vehicle.external_id) == str(vid))
+            and (str(saved_vehicle.source) == "clevertrack")
             and (saved_vehicle.plate == plate)
             and (saved_vehicle.imei == imei)
             and (saved_vehicle.description == description)
@@ -140,7 +141,7 @@ def set_vehicles(ctx, description_fields=None):
         # update data
         stmt = (
             update(Cars)
-            .where(Cars.id == vid)
+            .where((Cars.external_id == str(vid)) & (Cars.source == "clevertrack"))
             .values(plate=plate, imei=imei, description=description)
         )
         session.execute(stmt)

--- a/fleetmanager/extractors/fleetcomplete/updatedb.py
+++ b/fleetmanager/extractors/fleetcomplete/updatedb.py
@@ -134,7 +134,7 @@ def set_vehicles(ctx, description_fields=None, exempt_locations=False):
     vehicle_settings = pd.read_sql(Query(VehicleTypes).statement, engine)
     vehicles_response = requests.get(url + "Api/Vehicles/get", params=params)
     cars = json.loads(vehicles_response.content)["response"]
-    current_cars = {car.id: car.to_dict() for _, car in pd.read_sql(Query(Cars).statement, engine).iterrows()}
+    current_cars = {str(car.external_id): car.to_dict() for _, car in pd.read_sql(Query(Cars).statement, engine).iterrows() if car.source == "fleetcomplete"}
 
     if description_fields is not None:
         description_fields = description_fields.split(",")
@@ -144,7 +144,7 @@ def set_vehicles(ctx, description_fields=None, exempt_locations=False):
     for k, car in enumerate(cars):
         id_ = car["id"]
 
-        current_car = current_cars.get(id_, {})
+        current_car = current_cars.get(str(id_), {})
         if current_car and (current_car.get("disabled", False) or current_car.get("deleted", False)):
             continue
         if (
@@ -198,7 +198,8 @@ def set_vehicles(ctx, description_fields=None, exempt_locations=False):
                 )
 
         car_details = dict(
-            id=id_,
+            external_id=str(id_),
+            source="fleetcomplete",
             plate=plate,
             make=car["info"]["make"],
             model=car["info"]["model"],
@@ -248,11 +249,12 @@ def set_roundtrips(ctx):
             Query(Cars).filter(Cars.omkostning_aar.isnot(None)).statement, engine
         )
 
-        banned_cars = (
-            session.query(Cars.id)
+        banned_cars = [
+            car.id
+            for car in session.query(Cars.id)
             .filter(or_(Cars.deleted == True, Cars.disabled == True))
             .all()
-        )
+        ]
 
         for car in cars.itertuples():
             if car.id in banned_cars or pd.isna(car.location):
@@ -263,7 +265,7 @@ def set_roundtrips(ctx):
                 .filter(RoundTrips.car_id == car.id)
             )
             current_trips = get_trips(
-                car.id,
+                car.external_id,
                 ctx.obj["url"],
                 from_date=max_date,
                 start_location=car.location,
@@ -524,7 +526,7 @@ def location_precision_test(
     """
     function to test the precision with added parking spots
     """
-    carids = [str(car.id) for car in cars]
+    carids = [str(car.external_id) for car in cars]
     carid2key = {}
 
     car_url = "https://app.ecofleet.com/seeme/Api/Vehicles/get"
@@ -564,13 +566,13 @@ def location_precision_test(
     ]
 
     for car in cars:
-        if str(car.id) not in carid2key:
+        if str(car.external_id) not in carid2key:
             logger.info(f"Car id {car.id} not found in trackers amongst the keys")
             continue
-        params = {"key": carid2key[str(car.id)], "json": ""}
+        params = {"key": carid2key[str(car.external_id)], "json": ""}
 
         car_trips = get_trips(
-            car.id,
+            car.external_id,
             base_url,
             from_date=start_date,
             params=params

--- a/fleetmanager/extractors/gamfleet/updatedb.py
+++ b/fleetmanager/extractors/gamfleet/updatedb.py
@@ -167,12 +167,12 @@ def set_vehicles(ctx, description_fields=None):
             continue
         vehicle_id = int(vehicle_id)
         saved_vehicle = None
-        if vehicle_id in saved_vehicles.id.values:
-            saved_vehicle = saved_vehicles[saved_vehicles.id == vehicle_id].iloc[0]
+        if str(vehicle_id) in saved_vehicles[saved_vehicles.source == "gamfleet"].external_id.values:
+            saved_vehicle = saved_vehicles[(saved_vehicles.external_id == str(vehicle_id)) & (saved_vehicles.source == "gamfleet")].iloc[0]
 
         if saved_vehicle is not None and int(vehicle.get("IsActive")) == 0:
             # disable the vehicle
-            db_car = sess.get(Cars, vehicle_id)
+            db_car = sess.query(Cars).filter_by(external_id=str(vehicle_id), source="gamfleet").first()
             db_car.disabled = 1
             sess.commit()
             logger.info(f"Disabled vehicle {vehicle_id}")
@@ -198,7 +198,8 @@ def set_vehicles(ctx, description_fields=None):
             drivkraft = vehicle_information.get("drivkraft")
             drivkraft = None if drivkraft is None else drivkraft.lower()
             motor_register_car = {
-                "id": vehicle_id,
+                "external_id": str(vehicle_id),
+                "source": "gamfleet",
                 "make": vehicle_information.get("make"),
                 "model": vehicle_information.get("model"),
                 "range": vehicle_information.get("elektrisk_rækkevidde"),
@@ -238,7 +239,7 @@ def set_vehicles(ctx, description_fields=None):
             if new_location is None:
                 logger.info(f"New district name does not exist: {district_name}, skipping update on vehicle id {vehicle_id}")
                 continue
-            save_vehicle({"id": vehicle_id, "location": new_location.id}, sess)
+            save_vehicle({"external_id": str(vehicle_id), "source": "gamfleet", "location": new_location.id}, sess)
 
 
 @cli.command()
@@ -261,6 +262,7 @@ def set_roundtrips(ctx):
     query_vehicles = (
         sess.query(
             Cars.id,
+            Cars.external_id,
             Cars.location,
             func.coalesce(func.max(RoundTrips.end_time), max_date),
         )
@@ -271,8 +273,9 @@ def set_roundtrips(ctx):
             ),
             Cars.omkostning_aar.isnot(None),
             or_(Cars.wltp_el.isnot(None), Cars.wltp_fossil.isnot(None)),
+            Cars.source == "gamfleet"
         )
-        .group_by(Cars.id, Cars.location)
+        .group_by(Cars.id, Cars.external_id, Cars.location)
         .outerjoin(RoundTrips, RoundTrips.car_id == Cars.id)
     )
 
@@ -293,8 +296,8 @@ def set_roundtrips(ctx):
         logger.info("Initiating a new load record")
         load_record = {}
 
-    for car_id, car_location, last_date in query_vehicles:
-        if int(car_id) not in vehicle_ids:
+    for car_id, car_external_id, car_location, last_date in query_vehicles:
+        if int(car_external_id) not in vehicle_ids:
             continue
         if pd.isna(car_location):
             # no associated location
@@ -311,7 +314,7 @@ def set_roundtrips(ctx):
 
         logger.info(f"Updating car: {car_id}, last seen: {last_date}")
 
-        car_trips = get_logs(vehicle_id=car_id, from_date=last_date, to_date=now, url=url, params=params)
+        car_trips = get_logs(vehicle_id=int(car_external_id), from_date=last_date, to_date=now, url=url, params=params)
         if len(car_trips) == 0:
             continue
 
@@ -432,7 +435,7 @@ def location_precision_test(
     """
     function to test precision with new parking spots
     """
-    carids = [str(car.id) for car in cars]
+    carids = [str(car.external_id) for car in cars]
     carid2key = {}
 
     # for now only Helsingoer uses Gamfleet, hence the specifically created endpoint
@@ -471,16 +474,16 @@ def location_precision_test(
     ]
     now_date = datetime.combine(date.today(), dttime(0))
     for car in cars:
-        if str(car.id) not in carid2key:
+        if str(car.external_id) not in carid2key:
             logger.info(f"Car id {car.id} not found in trackers amongst the keys")
             continue
 
         car_trips = get_logs(
-            vehicle_id=car.id,
+            vehicle_id=car.external_id,
             from_date=start_date,
             to_date=now_date,
             url=trips_url,
-            params={"ApiKey": carid2key[str(car.id)]}
+            params={"ApiKey": carid2key[str(car.external_id)]}
         )
 
         if len(car_trips) == 0:

--- a/fleetmanager/extractors/mileagebook/updatedb.py
+++ b/fleetmanager/extractors/mileagebook/updatedb.py
@@ -227,13 +227,14 @@ def set_vehicles(ctx, description_fields=None):
         car_id = vehicle.get("InternalVehicleID")
 
         if vehicle.get("Status") not in allowed_statuses:
-            if car_id in saved_vehicles.id.values:
+            if str(car_id) in saved_vehicles[saved_vehicles.source == "mileagebook"].external_id.values:
                 # it's a known vehicle that is no longer in active status
                 change_status_disabled = True
         if vehicle.get("VehicleCategory") in disallowed_vehicle_categories:
             continue
         current_car = {
-            "id": car_id,
+            "external_id": str(car_id),
+            "source": "mileagebook",
             "leasing_type": (
                 None
                 if vehicle.get("LeasingType") == "None"
@@ -313,6 +314,7 @@ def set_roundtrips(ctx):
     query_vehicles = (
         sess.query(
             Cars.id,
+            Cars.external_id,
             Cars.location,
             func.coalesce(func.max(RoundTrips.end_time), max_date),
         )
@@ -323,8 +325,9 @@ def set_roundtrips(ctx):
             ),
             Cars.omkostning_aar.isnot(None),
             or_(Cars.wltp_el.isnot(None), Cars.wltp_fossil.isnot(None)),
+            Cars.source == "mileagebook",
         )
-        .group_by(Cars.id, Cars.location)
+        .group_by(Cars.id, Cars.external_id, Cars.location)
         .outerjoin(RoundTrips, RoundTrips.car_id == Cars.id)
     )
 
@@ -335,12 +338,12 @@ def set_roundtrips(ctx):
     collected_route_length = 0
     collected_route_count = 0
 
-    for car_id, car_location, last_date in query_vehicles:
+    for car_id, car_external_id, car_location, last_date in query_vehicles:
         if pd.isna(car_location):
             # no associated location
             continue
         logger.info(f"{car_id}, {last_date}")
-        trips_since_last_roundtrip = get_logs(car_id, last_date, url, headers)
+        trips_since_last_roundtrip = get_logs(car_external_id, last_date, url, headers)
         car_trips = format_trip_logs(
             trips_since_last_roundtrip, start_location_id=car_location
         )
@@ -564,7 +567,7 @@ def location_precision_test(
     """
     function to test the precision with added parking spots
     """
-    carids = [str(car.id) for car in cars]
+    carids = [str(car.external_id) for car in cars]
     carid2key = {}
 
     car_url = "https://enterpriseapi.mileagebook.com/api/Fleet/Cars"
@@ -604,11 +607,11 @@ def location_precision_test(
     ]
 
     for car in cars:
-        if str(car.id) not in carid2key:
+        if str(car.external_id) not in carid2key:
             logger.info(f"Car id {car.id} not found in trackers amongst the keys")
             continue
-        headers = {"X-Access-Token": carid2key[str(car.id)]}
-        trips_since_last_roundtrip = get_logs(car.id, start_date, trips_url, headers)
+        headers = {"X-Access-Token": carid2key[str(car.external_id)]}
+        trips_since_last_roundtrip = get_logs(car.external_id, start_date, trips_url, headers)
         car_trips = format_trip_logs(
             trips_since_last_roundtrip, start_location_id=location
         )

--- a/fleetmanager/extractors/puma/updatedb.py
+++ b/fleetmanager/extractors/puma/updatedb.py
@@ -127,7 +127,8 @@ def set_vehicles(ctx, description_fields=None):
             continue
 
         saved_vehicle = cars_in_db[
-            (cars_in_db.plate == vehicle.registreringsnummer.replace(" ", "")) | (cars_in_db.id == vehicle.nummer)
+            (cars_in_db.plate == vehicle.registreringsnummer.replace(" ", "")) | ((cars_in_db.external_id == str(vehicle.nummer)) &
+            (cars_in_db.source == "puma"))
         ]
         if len(saved_vehicle) > 1:
             logger.warning(
@@ -184,7 +185,8 @@ def set_vehicles(ctx, description_fields=None):
                 continue
             drivkraft = vehicle_attributes.get("drivkraft")
             new_car_object = {
-                "id": vehicle.nummer,
+                "external_id": str(vehicle.nummer),
+                "source": "puma",
                 "plate": plate,
                 "make": vehicle_attributes.get("make"),
                 "model": vehicle_attributes.get("model"),

--- a/fleetmanager/extractors/skyhost/updatedb.py
+++ b/fleetmanager/extractors/skyhost/updatedb.py
@@ -203,7 +203,7 @@ def set_roundtrips_v2(ctx):
     query_vehicles = (
         session.query(
             Cars.id,
-            Cars.imei,
+            Cars.external_id,
             Cars.location,
             func.coalesce(func.max(RoundTrips.end_time), max_date).label("max_date"),
         )
@@ -216,13 +216,13 @@ def set_roundtrips_v2(ctx):
             or_(Cars.wltp_el.isnot(None), Cars.wltp_fossil.isnot(None)),
             Cars.location.isnot(None)
         )
-        .group_by(Cars.id, Cars.location, Cars.imei)
+        .group_by(Cars.id, Cars.location, Cars.external_id)
         .outerjoin(RoundTrips, RoundTrips.car_id == Cars.id)
     )
 
     allowed_starts = get_allowed_starts_with_additions(session)
-    vehicles_imeis = {str(veh.imei): veh for veh in query_vehicles}  #  we got to identify by imei / externalid since Skyhost removed their legacy id
-    known_imeis = list(vehicles_imeis.keys())
+    vehicles_external_ids = {str(veh.external_id): veh for veh in query_vehicles}  # identify by external_id (skyhost removed their legacy id, so v2 stores the imei as external_id)
+    known_external_ids = list(vehicles_external_ids.keys())
     collected_trip_length = 0
     collected_trip_count = 0
     collected_route_length = 0
@@ -232,10 +232,10 @@ def set_roundtrips_v2(ctx):
         headers = {"Authorization": f"Bearer {api_key}"}
 
         for skyhost_vehicle in complete_vehicle_list:
-            if str(skyhost_vehicle.get("externalId")) not in known_imeis:
+            if str(skyhost_vehicle.get("externalId")) not in known_external_ids:
                 continue
             skyhost_device_id = skyhost_vehicle.get("id")
-            saved_vehicle = vehicles_imeis[str(skyhost_vehicle.get("externalId"))]
+            saved_vehicle = vehicles_external_ids[str(skyhost_vehicle.get("externalId"))]
             trips = get_trips_v2(
                 from_date=saved_vehicle.max_date,
                 to_date=now,

--- a/fleetmanager/extractors/skyhost/updatedb.py
+++ b/fleetmanager/extractors/skyhost/updatedb.py
@@ -319,7 +319,7 @@ def set_roundtrips(ctx):
 
     for car in cars.itertuples():
         if (
-            str(car.id) not in carid2key
+            str(car.external_id) not in carid2key
             or pd.isna(car.omkostning_aar)
             or pd.isna(car.location)
         ):
@@ -331,8 +331,9 @@ def set_roundtrips(ctx):
                 )
             ).fetchone()[0]
         current_trips = get_trips(
-            car.id, key=carid2key[str(car.id)], from_date=max_date
+            car.external_id, key=carid2key[str(car.external_id)], from_date=max_date
         )
+        current_trips["car_id"] = car.id
         # test which aggregates the most
         if len(current_trips) == 0:
             continue
@@ -389,7 +390,7 @@ def set_trackers_v2(ctx, description_fields=None):
         for vehicle_from_skyhost in complete_vehicle_list:
             imei = vehicle_from_skyhost.get("externalId")
             skyhost_id = vehicle_from_skyhost.get("id")
-            car_db = list(filter(lambda car: car.imei == imei, cars_in_db))
+            car_db = list(filter(lambda car: car.external_id == imei and car.source == "skyhost-v2", cars_in_db))
             if len(car_db) > 1:
                 logger.warning(f"There are multiple cars with the same imei number {imei}")
                 continue
@@ -405,13 +406,8 @@ def set_trackers_v2(ctx, description_fields=None):
             vehicle_details.update(**vehicle_from_skyhost)
             make, model = None, None
 
-            known_car = False
-            # the new object from skyhost rest does not support "old" id format, hence we use the external imei
-            if len(car_db) == 0:
-                id_ = imei
-            else:
-                known_car = True
-                id_ = car_db[0].id
+            known_car = len(car_db) == 1
+            if known_car:
                 make = car_db[0].make
                 model = car_db[0].model
 
@@ -434,7 +430,8 @@ def set_trackers_v2(ctx, description_fields=None):
             wltp_fossil = get_vehicle_wltp(vehicle_details.get("details", {}), "fossil")
             range_km = get_electrical_range(vehicle_details.get("details"))
             car = dict(
-                id=int(id_),
+                external_id = imei,
+                source = "skyhost-v2",
                 imei=imei,
                 plate=plate,
                 make=make,
@@ -507,14 +504,15 @@ def set_trackers(ctx, description_fields=None):
             continue
 
         with Session() as sess:
-            banned_cars = (
-                sess.query(Cars.id)
-                .filter(or_(Cars.deleted == True, Cars.disabled == True))
+            banned_cars = [
+                str(car.external_id)
+                for car in sess.query(Cars.external_id)
+                .filter(or_(Cars.deleted == True, Cars.disabled == True), Cars.source == "skyhost-v1")
                 .all()
-            )
+            ]
 
         for tracker in trackers.frame.itertuples():
-            if tracker.ID in banned_cars:
+            if str(tracker.ID) in banned_cars:
                 continue
             plate = tracker.Marker if tracker.Marker is not None and re.match(r"\w{2}\d{5}", str(tracker.Marker)) else None
             if plate is None and 'Description' in trackers.frame.columns:
@@ -522,7 +520,8 @@ def set_trackers(ctx, description_fields=None):
                 plate = None if description_plate_pattern is None else description_plate_pattern.group()
             # some times plate is in tracker.Marker
             car = dict(
-                id=tracker.ID,
+                external_id=str(tracker.ID),
+                source="skyhost-v1",
                 imei=tracker.IMEI,
                 plate=plate,
                 description=" ".join(
@@ -539,12 +538,12 @@ def set_trackers(ctx, description_fields=None):
                 "Description" in trackers.frame.columns and
                 (
                     tracker.Description in default_cars.plate.values
-                    or int(tracker.ID) in default_cars.id.values
+                    or str(tracker.ID) in default_cars.external_id.values
                 )
             ):
                 # we already know the car
                 # only thing we can update by now is the imei
-                saved_vehicle_object = sess.get(Cars, int(tracker.ID))
+                saved_vehicle_object = sess.query(Cars).filter_by(external_id=str(tracker.ID), source="skyhost-v1").first()
                 if saved_vehicle_object:
                     saved_vehicle_object.imei = car.get("imei")
                     if (plate and saved_vehicle_object.plate is None) or (
@@ -670,7 +669,10 @@ def set_trips(ctx):
                     }
 
         cars = pd.read_sql(
-            Query(Cars).filter(Cars.id.in_(trackers.frame.ID.values)).statement, engine
+            Query(Cars).filter(
+                Cars.external_id.in_([str(i) for i in trackers.frame.ID.values]),
+                Cars.source == "skyhost-v1",
+            ).statement, engine
         )
         for car in cars.itertuples():
             with engine.connect() as conn:
@@ -689,7 +691,7 @@ def set_trips(ctx):
             ):
                 logger.info(f"{start_month}, {end_month}")
                 dbook = driving_book(
-                    car.id,
+                    car.external_id,
                     start_month.isoformat(),
                     end_month.isoformat(),
                     agent,
@@ -784,7 +786,7 @@ def location_precision_test(
     """
     Function to test the precision of added parking spots
     """
-    carids = [str(car.id) for car in cars]
+    carids = [str(car.external_id) for car in cars]
     carid2key = {}
     for key in keys:
         if len(carid2key) == len(cars):
@@ -816,12 +818,12 @@ def location_precision_test(
     ]
 
     for car in cars:
-        if str(car.id) not in carid2key:
+        if str(car.external_id) not in carid2key:
             logger.info(f"Car id {car.id} not found in trackers amongst the keys")
             continue
 
         current_trips = get_trips(
-            car.id, key=carid2key[str(car.id)], from_date=start_date
+            car.external_id, key=carid2key[str(car.external_id)], from_date=start_date
         )
 
         if len(current_trips) == 0:

--- a/fleetmanager/extractors/skyhost/util.py
+++ b/fleetmanager/extractors/skyhost/util.py
@@ -167,7 +167,7 @@ def get_or_create(Session, model, parameters):
     returns the entry.
     """
     with Session.begin() as session:
-        instance = session.query(model).filter_by(id=parameters["id"]).first()
+        instance = session.query(model).filter_by(external_id=parameters["external_id"], source=parameters["source"]).first()
         if instance:
             session.expunge_all()
     if instance:

--- a/fleetmanager/extractors/util.py
+++ b/fleetmanager/extractors/util.py
@@ -425,8 +425,9 @@ def save_vehicle(car_dict: dict, session: Session, dmr_keys: list[str] = None):
     if dmr_keys is None:
         dmr_keys = []
 
-    car_id = car_dict.get("id")
-    saved_car = session.get(Cars, car_id)
+    external_id = car_dict.get("external_id")
+    source = car_dict.get("source")
+    saved_car = session.query(Cars).filter_by(external_id=external_id, source=source).first()
     car_columns = set(Cars.__table__.columns.keys())
 
     if saved_car is None:
@@ -434,13 +435,16 @@ def save_vehicle(car_dict: dict, session: Session, dmr_keys: list[str] = None):
         for key, ref_type in BACK_REF_TYPES.items():
             if (val := insert_dict.get(key)) is not None:
                 insert_dict[f"{key}_obj"] = session.get(ref_type, val)
-        session.add(Cars(**insert_dict))
+        new_car = Cars(**insert_dict)
+        session.add(new_car)
+        session.flush()
+        new_id = new_car.id
         session.commit()
-        logger.info(f"Inserted new vehicle id={car_id}")
+        logger.info(f"Inserted new vehicle id={new_id} external_id={external_id} source={source}")
         return
 
     for key, value in car_dict.items():
-        if key not in car_columns or key == "id":
+        if key not in car_columns or key in ("id", "external_id", "source"):
             continue
         try:
             if pd.isna(value):

--- a/fleetmanager/location/util.py
+++ b/fleetmanager/location/util.py
@@ -305,6 +305,15 @@ def precision_test(
         "SKYHOST_V2": {"precision_function": precision_test_skyhost_v2, "keys_key": "SKYHOST_V2_KEYS"}
     }
 
+    source_to_extractor = {   
+        "skyhost-v1": "SKYHOST",
+        "skyhost-v2": "SKYHOST_V2",
+        "mileagebook": "MILEAGEBOOK",
+        "gamfleet": "GAMFLEET",
+        "fleetcomplete": "FLEETCOMPLETE",
+        "puma": "PUMA",
+    }
+
     engine = engine_creator()
     session = sessionmaker(bind=engine)()
 
@@ -313,6 +322,8 @@ def precision_test(
         Cars.location,
         Cars.plate,  # puma extraction is dependent on the plate
         Cars.imei,  # skyhostV2 is dependent on imei as externalid
+        Cars.external_id,
+        Cars.source,
     ).filter(
         Cars.location == location,
         Cars.omkostning_aar.isnot(None),
@@ -328,6 +339,9 @@ def precision_test(
     ).all()
 
     len_cars = len(cars)
+    present_sources = {car.source for car in cars}
+    needed = {source_to_extractor[s] for s in present_sources if s in source_to_extractor}
+    extractors = [e for e in extractors if e in needed]
     results = []
     response = PrecisionTestResults(
         test_settings=PrecisionTestIn(

--- a/fleetmanager/tests/unit/test_configuration_util.py
+++ b/fleetmanager/tests/unit/test_configuration_util.py
@@ -100,7 +100,6 @@ def test_create_delete_vehicle(db_session):
     # Step 3: Get existing car count to calculate expected new ID
     existing_cars = db_session.query(Cars).all()
     existing_max_id = max([c.id for c in existing_cars]) if existing_cars else 0
-    expected_new_id = max(1000000, existing_max_id + 1)
 
     # Step 4: Use type 3 (elbil) with fuel 3 (el) - confirmed compatible
     # Provide all required fields (Pydantic v2 requires explicit None for optional fields without defaults)
@@ -132,7 +131,7 @@ def test_create_delete_vehicle(db_session):
 
     # Verify creation succeeded
     assert isinstance(saved_id, int), f"Vehicle creation failed with error: {saved_id}"
-    assert saved_id == expected_new_id, f"Expected ID {expected_new_id}, got {saved_id}"
+    assert saved_id > existing_max_id, f"Expected DB-assigned id > {existing_max_id}, got {saved_id}"
 
     # Step 6: Verify retrieval
     saved_vehicle = get_single_vehicle(db_session, vehicle_id=saved_id)

--- a/fleetmanager/tests/unit/test_save_vehicle.py
+++ b/fleetmanager/tests/unit/test_save_vehicle.py
@@ -1,0 +1,50 @@
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from fleetmanager.data_access.dbschema import Base, Cars
+from fleetmanager.extractors.util import save_vehicle
+
+
+def _session():
+    # in-memory sqlite, StaticPool so create_all + the session share one connection
+    engine = sa.create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def test_inserts_new_vehicle_with_db_assigned_id():
+    s = _session()
+    save_vehicle({"external_id": "imei-1", "source": "skyhost", "plate": "AB12345"}, s)
+
+    car = s.query(Cars).one()
+    assert car.external_id == "imei-1"
+    assert car.source == "skyhost"
+    assert car.id is not None  # assigned by the database, not by us
+
+
+def test_updates_existing_match_on_external_id_and_source():
+    s = _session()
+    save_vehicle({"external_id": "imei-1", "source": "skyhost", "plate": "AB12345"}, s)
+    first_id = s.query(Cars).one().id
+
+    # same (external_id, source), new plate -> should update, not create a duplicate
+    save_vehicle({"external_id": "imei-1", "source": "skyhost", "plate": "XY99999"}, s)
+
+    cars = s.query(Cars).all()
+    assert len(cars) == 1
+    assert cars[0].id == first_id
+    assert cars[0].plate == "XY99999"
+
+
+def test_same_external_id_different_source_are_distinct_cars():
+    s = _session()
+    save_vehicle({"external_id": "5", "source": "skyhost"}, s)
+    save_vehicle({"external_id": "5", "source": "puma"}, s)
+
+    # same external id but different vendor -> two distinct cars
+    assert s.query(Cars).count() == 2


### PR DESCRIPTION
Closes #298. Implements the sub-issues #299, #302 and #303.

  ## What & why
  The `Cars.id` column was overloaded: it held both the internal primary key
  and the vendor's external identifier, and manual vehicles relied on an
  `id >= 1000000` hack. This coupling made it impossible to have the same
  external id across two vendors and forced us to fabricate ids.


  - **#299 — schema:** add `external_id` and `source` columns to `Cars`, and
    make `id` a normal database-assigned autoincrement primary key.
  - **#302 — extractors:** every extractor now resolves vehicles by
    `(external_id, source)` instead of by `id`. Vendor API calls use
    `external_id`; foreign keys keep using the internal `id`.
  - **#303 — drop the id hack:** manual vehicle creation no longer sets a
    magic `id`; the database assigns it. `update_single_vehicle` is guarded
    so manual edits can't null out `external_id`/`source`.
  
  ## Tests
  - `test_save_vehicle.py` — new: insert with db-assigned id, update on
    `(external_id, source)` match, same external id across vendors stays distinct.
  - `test_configuration_util.py` — asserts the db-assigned id.