### PR TITLE
Fixes #228 -- guard empty heatmap data on activity dashboards

### DIFF
--- a/fleetoptimiser-frontend/app/(logged-in)/dashboard/activity/(VehicleActivity)/DrivingHeatmap.tsx
+++ b/fleetoptimiser-frontend/app/(logged-in)/dashboard/activity/(VehicleActivity)/DrivingHeatmap.tsx
@@ -27,7 +27,8 @@ export const DrivingHeatmapKm = ({
     maxHeatValue?: number;
     setLocationZoom: (cell: ComputedCell<HeatMapGroupWithMetaData>) => void;
 }) => {
-    const showLabels = useMediaQuery({ minWidth: '1280px' }) && data[0].data.length <= 31; // labels become cluttered below width and with many cells
+    const showLabels = useMediaQuery({ minWidth: '1280px' }) && (data[0]?.data.length ?? 0) <= 31; // labels become cluttered below width and with many cells
+    if (!data.length) return <p className="m-4">Ingen kørselsdata for de valgte filtre.</p>
     return (
         <div className="hover:cursor-pointer h-full">
             <ResponsiveHeatMapCanvas

--- a/fleetoptimiser-frontend/app/(logged-in)/dashboard/timeactivity/(TimeActivity)/TimeActivityHeatMap.tsx
+++ b/fleetoptimiser-frontend/app/(logged-in)/dashboard/timeactivity/(TimeActivity)/TimeActivityHeatMap.tsx
@@ -14,7 +14,8 @@ export type heatmapData = {
 }[];
 
 export default function TimeActivityHeatMap({ data, threshold }: { data: heatmapData; threshold: number }) {
-    const showLabels = useMediaQuery({ minWidth: '1280px' }) && data[0].data.length <= 31;
+    const showLabels = useMediaQuery({ minWidth: '1280px' }) && (data[0]?.data.length ?? 0) <= 31;
+    if(!data.length) return <p className="m-4">Ingen kørselsdata for de valgte filtre </p>
     // labels become cluttered if below 1280px or more than 31 days
     const lightTextMax = (threshold / 100) * 0.4;
     return (


### PR DESCRIPTION
 Closes #228.

  ## Problem
  The activity dashboards crashed with `TypeError: can't access property "data", data[0] is undefined` when a filter combination returned no vehicle
  data — reachable via a direct link, e.g. the reported URL filtering on a location + `HEM/Vaccinationscenter` where no vehicle matches.

  ## Root cause
  `DrivingHeatmapKm` (and its twin `TimeActivityHeatMap`) read `data[0].data.length` without guarding for an empty array. The parent only guards
  `{heatMapData.data && …}`, but an empty array is truthy, so the heatmap still renders with `data = []` and crashes. `query_vehicles` can be empty
  while `query_locations` is not (a department filter narrows vehicles but not locations), so the "Køretøjer" tab hits this while "Lokationer" works.
  
  ## Fix
  Guard both heatmap components:
  - null-safe label check: `(data[0]?.data.length ?? 0) <= 31`
  - render an empty-state message when `data` is empty, placed after the hook call to respect the rules of hooks.

  ## Verification
  Reproduced locally via `/dashboard/activity?locations=<id>&departments=<dept>` with a location/department combo that has no vehicles → crashed before, shows the empty-state message after. Verified on both Kørselsaktivitet (`DrivingHeatmap`) and Tidsaktivitet (`TimeActivityHeatMap`).